### PR TITLE
cyclonedx-export.bbclass: Add relationship between dependencies

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -409,12 +409,12 @@ python do_deploy_cyclonedx() {
                                 comp = bom_ref_map[alias_map[depends]] 
                                 if comp not in pn_list["pkgs"] :
                                     pn_list["pkgs"].append(comp)
+                if resolved_depends :
+                    updated_entry = {"ref": dep_entry["ref"], "dependsOn": resolved_depends}
+                    pn_list["dependencies"].append(updated_entry)
                 
-                updated_entry = {"ref": dep_entry["ref"], "dependsOn": resolved_depends}
-                pn_list["dependencies"].append(updated_entry)
-                
-                if updated_entry not in sbom["dependencies"]:
-                    sbom["dependencies"].append(updated_entry)
+                    if updated_entry not in sbom["dependencies"]:
+                        sbom["dependencies"].append(updated_entry)
             
             write_json(pn_list_filepath, pn_list)
 

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -182,7 +182,6 @@ def resolve_dependency_ref(depends, bom_ref_map, alias_map):
     """
     Replace dependency name by his bom-ref attribute
     """
-    import re 
 
     # Direct
     if depends in bom_ref_map:
@@ -193,12 +192,7 @@ def resolve_dependency_ref(depends, bom_ref_map, alias_map):
         real_name = alias_map[depends]
         if real_name in bom_ref_map:
             return bom_ref_map[real_name]["bom-ref"]
-    
-    # Clean and resolve
-    sanitized_name = re.sub(r"[0-9\- .]", "", depends)
-    if sanitized_name in bom_ref_map:
-        return bom_ref_map[sanitized_name]["bom-ref"]
-    
+
     # Return None if no solution found
     return None
 

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -95,6 +95,27 @@ python do_cyclonedx_package_collect() {
     # append any cve status within recipe to pn_list cves
     pn_list["cves"] = cves
 
+    # Add dependencies
+    dependencies = []
+
+    for comp in pn_list["pkgs"]:
+        main_ref = comp.get("bom-ref")
+        if not main_ref:
+            continue
+
+        dep_entry = {
+            "ref": main_ref,
+            "dependsOn": []
+        }
+
+        for dep_name in get_recipe_dependencies(d):
+            dep_entry["dependsOn"].append(dep_name)
+
+        if dep_entry["dependsOn"]:
+            dependencies.append(dep_entry)
+
+    pn_list["dependencies"] = dependencies
+
     # write partial sbom to the recipes work folder
     write_json(d.getVar("CYCLONEDX_TMP_PN_LIST"), pn_list)
 }
@@ -130,6 +151,65 @@ def write_json(path, content):
     Path(path).write_text(
         json.dumps(content, indent=2)
     )
+
+
+def get_recipe_dependencies(d):
+    """ 
+    Return recipe names which depend on the current one.
+    Combines DEPENDS and RDEPENDS if CYCLONEDX_RUNTIME_PACKAGES_ONLY is set to 0.
+    """
+    runtime_only = d.getVar("CYCLONEDX_RUNTIME_PACKAGES_ONLY") == "1"
+    pn = d.getVar("PN")
+    runtime_deps = (d.getVar("RDEPENDS_" + pn) or "").split()
+    ignored_suffixes = set((d.getVar("SPECIAL_PKGSUFFIX") or "").split())
+
+    if runtime_only:
+        deps = runtime_deps
+    else:
+        build_deps = (d.getVar("DEPENDS") or "").split()
+        deps = build_deps + runtime_deps
+
+    # Resolves virtual/* dependencies to their preferred providers.
+    resolved_deps = set()
+    for dep in deps:
+        dep = dep.strip()
+        if not dep:
+            continue
+        # If package is virtual, we retrieve his provider
+        if dep.startswith("virtual/"):
+            dep = d.getVar("PREFERRED_PROVIDER_" + dep) or dep
+        # ignore non-target packages
+        if any(dep.endswith(suffix) for suffix in ignored_suffixes):
+            continue
+        
+        resolved_deps.add(dep)
+
+    return list(resolved_deps)
+
+def resolve_dependency_ref(depends, bom_ref_map, alias_map):
+    """
+    Replace dependency name by his bom-ref attribute
+    """
+    import re 
+
+    # Direct
+    if depends in bom_ref_map:
+        return bom_ref_map[depends]["bom-ref"]
+    
+    # By Alias
+    if depends in alias_map:
+        real_name = alias_map[depends]
+        if real_name in bom_ref_map:
+            return bom_ref_map[real_name]["bom-ref"]
+    
+    # Clean and resolve
+    cleaned_name = re.sub(r"[0-9\- .]", "", depends)
+    if cleaned_name in bom_ref_map:
+        return bom_ref_map[cleaned_name]["bom-ref"]
+    
+    # Retourner None si aucune résolution trouvée
+    return None
+
 
 def generate_packages_list(products_names, version):
     """
@@ -186,8 +266,7 @@ def append_to_vex(d, cve, cves, bom_ref):
 
     detail_string = ""
     detail_string += f"STATE: {status}\n"
-    if justification:
-        detail_string += f"JUSTIFICATION: {justification}\n"
+    detail_string += f"JUSTIFICATION: {justification}\n"
 
     cves.append({
         "id": cve_id,
@@ -230,7 +309,8 @@ python do_deploy_cyclonedx() {
             "timestamp": timestamp,
             "tools": [{"name": "yocto"}]
         },
-        "components": []
+        "components": [],
+        "dependencies": []
     }
 
     # Generate vex document header
@@ -261,8 +341,30 @@ python do_deploy_cyclonedx() {
             recipes.add(pkg_data["PN"])
     else:
         recipes = {pn for pn in os.listdir(cyclonedx_work_dir_root) if os.path.isdir(os.path.join(cyclonedx_work_dir_root, pn))}
-
+        
     save_pn = d.getVar("PN")
+
+    # Create a bom_ref_map for dependencies sanitarization
+    # And an alias_map to retrieve real pkg name
+    bom_ref_map = {}
+    alias_map = {}
+
+    # first loop to fill the dictionary
+    for pkg in recipes:
+        # To be able to use the CYCLONEDX_WORK_DIR_PN_LIST variable we have to evaluate
+        # it with the different PN names set each time.
+        d.setVar("PN", pkg)
+
+        pn_list_filepath = d.getVar("CYCLONEDX_WORK_DIR_PN_LIST")
+
+        if not os.path.exists(pn_list_filepath):
+            continue
+
+        pn_list = read_json(pn_list_filepath)
+        for pn_pkg in pn_list["pkgs"]:
+            bom_ref_map[pn_pkg["name"]]=pn_pkg
+            alias_map[d.getVar("PN")]=pn_pkg["name"]
+
     for pkg in recipes:
         # To be able to use the CYCLONEDX_WORK_DIR_PN_LIST variable we have to evaluate
         # it with the different PN names set each time.
@@ -286,6 +388,32 @@ python do_deploy_cyclonedx() {
             pn_cve["affects"][0]["ref"] = pn_cve["affects"][0]["ref"].replace(
                 d.getVar('CYCLONEDX_SBOM_SERIAL_PLACEHOLDER'), sbom_serial_number)
             vex["vulnerabilities"].append(pn_cve)
+
+        # Add dependencies
+        if deps := pn_list.get("dependencies"):
+            pn_list["dependencies"] = []
+            
+            for dep_entry in deps:
+                resolved_depends = []
+                
+                for depends in dep_entry["dependsOn"]:
+                    if resolved_ref := resolve_dependency_ref(depends, bom_ref_map, alias_map):
+                        if resolved_ref not in resolved_depends:
+                            resolved_depends.append(resolved_ref)
+                            
+                            # Add component to isolate file
+                            if ((depends in alias_map) and (alias_map[depends] in bom_ref_map)):
+                                comp = bom_ref_map[alias_map[depends]] 
+                                if comp not in pn_list["pkgs"] :
+                                    pn_list["pkgs"].append(comp)
+                
+                updated_entry = {"ref": dep_entry["ref"], "dependsOn": resolved_depends}
+                pn_list["dependencies"].append(updated_entry)
+                
+                if updated_entry not in sbom["dependencies"]:
+                    sbom["dependencies"].append(updated_entry)
+            
+            write_json(pn_list_filepath, pn_list)
 
     d.setVar("PN", save_pn)
 

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -266,7 +266,8 @@ def append_to_vex(d, cve, cves, bom_ref):
 
     detail_string = ""
     detail_string += f"STATE: {status}\n"
-    detail_string += f"JUSTIFICATION: {justification}\n"
+    if justification:
+        detail_string += f"JUSTIFICATION: {justification}\n"
 
     cves.append({
         "id": cve_id,


### PR DESCRIPTION
Add relationships between dependencies

This feature will introduce:

- Dependency relationships for each component, both in individual files and in the final SBOM.
- In the pn_list single file, only the components directly depended upon by the main component will be listed, excluding their own dependencies. This ensures the focus remains on the primary component's importance.
