### PR TITLE
Include component licence info

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -78,19 +78,28 @@ python do_cyclonedx_package_collect() {
     cves = []
     # append all defined package names for recipe to pn_list pkgs
     for pkg in generate_packages_list(name, version):
-        if not next((c for c in pn_list["pkgs"] if c["cpe"] == pkg["cpe"]), None):
-            pn_list["pkgs"].append(pkg)
-            bom_ref = pkg["bom-ref"]
+        if next((c for c in pn_list["pkgs"] if c["cpe"] == pkg["cpe"]), None):
+            continue
 
-            # append any CVEs either patched or taken from CVE_STATUS
-            for cve_id, cve_info in get_patched_cves(d).items():
-                cve = (
-                    cve_id,
-                    cve_info["abbrev-status"],
-                    cve_info["status"],
-                    cve_info.get("justification", "")
-                )
-                append_to_vex(d, cve, cves, bom_ref)
+        bb.debug(2, f"Resolving license for {pkg['name']}")
+        license = resolve_license_data(d)
+        if license is not None:
+            pkg["licenses"] = license
+        else:
+            bb.warn(f"LICENSE variable not set for package {pn}")
+
+        pn_list["pkgs"].append(pkg)
+        bom_ref = pkg["bom-ref"]
+
+        # append any CVEs either patched or taken from CVE_STATUS
+        for cve_id, cve_info in get_patched_cves(d).items():
+            cve = (
+                cve_id,
+                cve_info["abbrev-status"],
+                cve_info["status"],
+                cve_info.get("justification", "")
+            )
+            append_to_vex(d, cve, cves, bom_ref)
 
     # append any cve status within recipe to pn_list cves
     pn_list["cves"] = cves
@@ -152,6 +161,43 @@ def write_json(path, content):
         json.dumps(content, indent=2)
     )
 
+def resolve_license_data(d):
+    """
+    Resolves a given recipe LICENSE (see: https://docs.yoctoproject.org/singleindex.html#term-LICENSE)
+    for use in CycloneDX
+    """
+    # load spdx license identifiers
+    layerdir = d.getVar("CYCLONEDX_LAYERDIR")
+    licenses_file_path = f"{layerdir}/meta/files/spdx-license-list-data/licenses.json"
+    bb.debug(2, f"Loading SPDX licenses from {licenses_file_path}")
+    licenses_json = read_json(licenses_file_path)
+    spdx_licenses = [l["licenseId"] for l in licenses_json["licenses"]]
+
+    license = d.getVar("LICENSE", True)
+
+    license_info = None
+    # Check if the license is an expression
+    if "|" in license or "&" in license:
+        bb.debug(2, f"Adding {license} as expression.")
+        license_info = [{"expression": license}]
+
+    # Else if license is a known SPDX license, use license.id
+    elif license in spdx_licenses:
+        bb.debug(2, f"Found license {license} in in SPDX license IDs.")
+        license_info = [{"license": {"id": license}}]
+
+    # Else if there is a matching license mapping and it is a SPDX license ID
+    elif d.getVarFlag("SPDXLICENSEMAP", license) is not None and d.getVarFlag("SPDXLICENSEMAP", license) in spdx_licenses:
+        mapped_license = d.getVarFlag("SPDXLICENSEMAP", license)
+        bb.debug(2, f"Found SPDX ID mapping {mapped_license} for license {license}.")
+        license_info = [{"license": {"id": mapped_license}}]
+
+    # Else add this as license[0].name
+    else:
+        bb.debug(2, f"Unknown license {license}. Using raw name.")
+        license_info = [{"license": {"name": license}}]
+
+    return license_info
 
 def get_recipe_dependencies(d):
     """

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -3,6 +3,8 @@
 # We have a conf and classes directory, append to BBPATH
 BBPATH .= ":${LAYERDIR}"
 
+CYCLONEDX_LAYERDIR = "${LAYERDIR}"
+
 BBFILE_COLLECTIONS += "cyclonedx"
 BBFILE_PATTERN_cyclonedx = "^${LAYERDIR}/"
 

--- a/meta/files/spdx-license-list-data/README.md
+++ b/meta/files/spdx-license-list-data/README.md
@@ -1,0 +1,7 @@
+# SPDX License List Data
+
+This folder contains known SPDX licenses, as published [here](https://github.com/spdx/license-list-data).
+
+While poky comes with it's own spdx license list (poky/meta/files/spdx-licenses.json),
+the license list data version must align with the CycloneDX spec version.
+For example, CycloneDX 1.4 uses [v3.12](https://github.com/CycloneDX/specification/blob/1.4/schema/spdx.schema.json#L4)

--- a/meta/files/spdx-license-list-data/licenses.json
+++ b/meta/files/spdx-license-list-data/licenses.json
@@ -1,0 +1,5622 @@
+{
+  "licenseListVersion": "3.12",
+  "licenses": [
+    {
+      "reference": "./AFL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AFL-2.0.html",
+      "referenceNumber": 0,
+      "name": "Academic Free License v2.0",
+      "licenseId": "AFL-2.0",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AAL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AAL.html",
+      "referenceNumber": 1,
+      "name": "Attribution Assurance License",
+      "licenseId": "AAL",
+      "seeAlso": [
+        "https://opensource.org/licenses/attribution"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Adobe-2006.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Adobe-2006.html",
+      "referenceNumber": 2,
+      "name": "Adobe Systems Incorporated Source Code License Agreement",
+      "licenseId": "Adobe-2006",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AFL-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AFL-3.0.html",
+      "referenceNumber": 3,
+      "name": "Academic Free License v3.0",
+      "licenseId": "AFL-3.0",
+      "seeAlso": [
+        "http://www.rosenlaw.com/AFL3.0.htm",
+        "https://opensource.org/licenses/afl-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ADSL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ADSL.html",
+      "referenceNumber": 4,
+      "name": "Amazon Digital Services License",
+      "licenseId": "ADSL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./0BSD.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./0BSD.html",
+      "referenceNumber": 5,
+      "name": "BSD Zero Clause License",
+      "licenseId": "0BSD",
+      "seeAlso": [
+        "http://landley.net/toybox/license.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Afmparse.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Afmparse.html",
+      "referenceNumber": 6,
+      "name": "Afmparse License",
+      "licenseId": "Afmparse",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Afmparse"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AFL-1.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AFL-1.2.html",
+      "referenceNumber": 7,
+      "name": "Academic Free License v1.2",
+      "licenseId": "AFL-1.2",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.2.txt",
+        "http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AGPL-1.0-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AGPL-1.0-or-later.html",
+      "referenceNumber": 8,
+      "name": "Affero General Public License v1.0 or later",
+      "licenseId": "AGPL-1.0-or-later",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AFL-2.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AFL-2.1.html",
+      "referenceNumber": 9,
+      "name": "Academic Free License v2.1",
+      "licenseId": "AFL-2.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AFL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AFL-1.1.html",
+      "referenceNumber": 10,
+      "name": "Academic Free License v1.1",
+      "licenseId": "AFL-1.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.1.txt",
+        "http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AGPL-1.0.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./AGPL-1.0.html",
+      "referenceNumber": 11,
+      "name": "Affero General Public License v1.0",
+      "licenseId": "AGPL-1.0",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Adobe-Glyph.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Adobe-Glyph.html",
+      "referenceNumber": 12,
+      "name": "Adobe Glyph List License",
+      "licenseId": "Adobe-Glyph",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AMDPLPA.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AMDPLPA.html",
+      "referenceNumber": 13,
+      "name": "AMD\u0027s plpa_map.c License",
+      "licenseId": "AMDPLPA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Aladdin.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Aladdin.html",
+      "referenceNumber": 14,
+      "name": "Aladdin Free Public License",
+      "licenseId": "Aladdin",
+      "seeAlso": [
+        "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ANTLR-PD.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ANTLR-PD.html",
+      "referenceNumber": 15,
+      "name": "ANTLR Software Rights Notice",
+      "licenseId": "ANTLR-PD",
+      "seeAlso": [
+        "http://www.antlr2.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AML.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AML.html",
+      "referenceNumber": 16,
+      "name": "Apple MIT License",
+      "licenseId": "AML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Apache-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Apache-1.0.html",
+      "referenceNumber": 17,
+      "name": "Apache License 1.0",
+      "licenseId": "Apache-1.0",
+      "seeAlso": [
+        "http://www.apache.org/licenses/LICENSE-1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ANTLR-PD-fallback.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ANTLR-PD-fallback.html",
+      "referenceNumber": 18,
+      "name": "ANTLR Software Rights Notice with license fallback",
+      "licenseId": "ANTLR-PD-fallback",
+      "seeAlso": [
+        "http://www.antlr2.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Abstyles.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Abstyles.html",
+      "referenceNumber": 19,
+      "name": "Abstyles License",
+      "licenseId": "Abstyles",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Abstyles"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AGPL-1.0-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AGPL-1.0-only.html",
+      "referenceNumber": 20,
+      "name": "Affero General Public License v1.0 only",
+      "licenseId": "AGPL-1.0-only",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./APAFML.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./APAFML.html",
+      "referenceNumber": 21,
+      "name": "Adobe Postscript AFM License",
+      "licenseId": "APAFML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./APSL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./APSL-1.0.html",
+      "referenceNumber": 22,
+      "name": "Apple Public Source License 1.0",
+      "licenseId": "APSL-1.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./APSL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./APSL-1.1.html",
+      "referenceNumber": 23,
+      "name": "Apple Public Source License 1.1",
+      "licenseId": "APSL-1.1",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./APSL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./APSL-2.0.html",
+      "referenceNumber": 24,
+      "name": "Apple Public Source License 2.0",
+      "licenseId": "APSL-2.0",
+      "seeAlso": [
+        "http://www.opensource.apple.com/license/apsl/"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AGPL-3.0-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AGPL-3.0-only.html",
+      "referenceNumber": 25,
+      "name": "GNU Affero General Public License v3.0 only",
+      "licenseId": "AGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Apache-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Apache-1.1.html",
+      "referenceNumber": 26,
+      "name": "Apache License 1.1",
+      "licenseId": "Apache-1.1",
+      "seeAlso": [
+        "http://apache.org/licenses/LICENSE-1.1",
+        "https://opensource.org/licenses/Apache-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Apache-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Apache-2.0.html",
+      "referenceNumber": 27,
+      "name": "Apache License 2.0",
+      "licenseId": "Apache-2.0",
+      "seeAlso": [
+        "http://www.apache.org/licenses/LICENSE-2.0",
+        "https://opensource.org/licenses/Apache-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./APL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./APL-1.0.html",
+      "referenceNumber": 28,
+      "name": "Adaptive Public License 1.0",
+      "licenseId": "APL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/APL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Bahyph.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Bahyph.html",
+      "referenceNumber": 29,
+      "name": "Bahyph License",
+      "licenseId": "Bahyph",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Bahyph"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Artistic-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Artistic-1.0.html",
+      "referenceNumber": 30,
+      "name": "Artistic License 1.0",
+      "licenseId": "Artistic-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Artistic-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AMPAS.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AMPAS.html",
+      "referenceNumber": 31,
+      "name": "Academy of Motion Picture Arts and Sciences BSD",
+      "licenseId": "AMPAS",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Barr.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Barr.html",
+      "referenceNumber": 32,
+      "name": "Barr License",
+      "licenseId": "Barr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Barr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AGPL-3.0-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./AGPL-3.0-or-later.html",
+      "referenceNumber": 33,
+      "name": "GNU Affero General Public License v3.0 or later",
+      "licenseId": "AGPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BlueOak-1.0.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BlueOak-1.0.0.html",
+      "referenceNumber": 34,
+      "name": "Blue Oak Model License 1.0.0",
+      "licenseId": "BlueOak-1.0.0",
+      "seeAlso": [
+        "https://blueoakcouncil.org/license/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Beerware.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Beerware.html",
+      "referenceNumber": 35,
+      "name": "Beerware License",
+      "licenseId": "Beerware",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Beerware",
+        "https://people.freebsd.org/~phk/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Artistic-1.0-cl8.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Artistic-1.0-cl8.html",
+      "referenceNumber": 36,
+      "name": "Artistic License 1.0 w/clause 8",
+      "licenseId": "Artistic-1.0-cl8",
+      "seeAlso": [
+        "https://opensource.org/licenses/Artistic-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./blessing.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./blessing.html",
+      "referenceNumber": 37,
+      "name": "SQLite Blessing",
+      "licenseId": "blessing",
+      "seeAlso": [
+        "https://www.sqlite.org/src/artifact/e33a4df7e32d742a?ln\u003d4-9",
+        "https://sqlite.org/src/artifact/df5091916dbb40e6"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Borceux.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Borceux.html",
+      "referenceNumber": 38,
+      "name": "Borceux license",
+      "licenseId": "Borceux",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Borceux"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-2-Clause-NetBSD.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./BSD-2-Clause-NetBSD.html",
+      "referenceNumber": 39,
+      "name": "BSD 2-Clause NetBSD License",
+      "licenseId": "BSD-2-Clause-NetBSD",
+      "seeAlso": [
+        "http://www.netbsd.org/about/redistribution.html#default"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-1-Clause.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-1-Clause.html",
+      "referenceNumber": 40,
+      "name": "BSD 1-Clause License",
+      "licenseId": "BSD-1-Clause",
+      "seeAlso": [
+        "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision\u003d326823"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-2-Clause-Patent.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-2-Clause-Patent.html",
+      "referenceNumber": 41,
+      "name": "BSD-2-Clause Plus Patent License",
+      "licenseId": "BSD-2-Clause-Patent",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSDplusPatent"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BitTorrent-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BitTorrent-1.0.html",
+      "referenceNumber": 42,
+      "name": "BitTorrent Open Source License v1.0",
+      "licenseId": "BitTorrent-1.0",
+      "seeAlso": [
+        "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1\u003d1.1\u0026r2\u003d1.1.1.1\u0026diff_format\u003ds"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-2-Clause-FreeBSD.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./BSD-2-Clause-FreeBSD.html",
+      "referenceNumber": 43,
+      "name": "BSD 2-Clause FreeBSD License",
+      "licenseId": "BSD-2-Clause-FreeBSD",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/freebsd-license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-Attribution.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-3-Clause-Attribution.html",
+      "referenceNumber": 44,
+      "name": "BSD with attribution",
+      "licenseId": "BSD-3-Clause-Attribution",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-2-Clause.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-2-Clause.html",
+      "referenceNumber": 45,
+      "name": "BSD 2-Clause \"Simplified\" License",
+      "licenseId": "BSD-2-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-2-Clause"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./APSL-1.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./APSL-1.2.html",
+      "referenceNumber": 46,
+      "name": "Apple Public Source License 1.2",
+      "licenseId": "APSL-1.2",
+      "seeAlso": [
+        "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-3-Clause-LBNL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-3-Clause-LBNL.html",
+      "referenceNumber": 47,
+      "name": "Lawrence Berkeley National Labs BSD variant license",
+      "licenseId": "BSD-3-Clause-LBNL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Artistic-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Artistic-2.0.html",
+      "referenceNumber": 48,
+      "name": "Artistic License 2.0",
+      "licenseId": "Artistic-2.0",
+      "seeAlso": [
+        "http://www.perlfoundation.org/artistic_license_2_0",
+        "https://www.perlfoundation.org/artistic-license-20.html",
+        "https://opensource.org/licenses/artistic-license-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-3-Clause-No-Nuclear-License-2014.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-3-Clause-No-Nuclear-License-2014.html",
+      "referenceNumber": 49,
+      "name": "BSD 3-Clause No Nuclear License 2014",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
+      "seeAlso": [
+        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-Modification.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-3-Clause-Modification.html",
+      "referenceNumber": 50,
+      "name": "BSD 3-Clause Modification",
+      "licenseId": "BSD-3-Clause-Modification",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:BSD#Modification_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-4-Clause-Shortened.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-4-Clause-Shortened.html",
+      "referenceNumber": 51,
+      "name": "BSD 4 Clause Shortened",
+      "licenseId": "BSD-4-Clause-Shortened",
+      "seeAlso": [
+        "https://metadata.ftp-master.debian.org/changelogs//main/a/arpwatch/arpwatch_2.1a15-7_copyright"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-3-Clause.html",
+      "referenceNumber": 52,
+      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+      "licenseId": "BSD-3-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-3-Clause"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-3-Clause-Open-MPI.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-3-Clause-Open-MPI.html",
+      "referenceNumber": 53,
+      "name": "BSD 3-Clause Open MPI variant",
+      "licenseId": "BSD-3-Clause-Open-MPI",
+      "seeAlso": [
+        "https://www.open-mpi.org/community/license.php",
+        "http://www.netlib.org/lapack/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BitTorrent-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BitTorrent-1.1.html",
+      "referenceNumber": 54,
+      "name": "BitTorrent Open Source License v1.1",
+      "licenseId": "BitTorrent-1.1",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-No-Nuclear-Warranty.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-3-Clause-No-Nuclear-Warranty.html",
+      "referenceNumber": 55,
+      "name": "BSD 3-Clause No Nuclear Warranty",
+      "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
+      "seeAlso": [
+        "https://jogamp.org/git/?p\u003dgluegen.git;a\u003dblob_plain;f\u003dLICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-Source-Code.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-Source-Code.html",
+      "referenceNumber": 56,
+      "name": "BSD Source Code Attribution",
+      "licenseId": "BSD-Source-Code",
+      "seeAlso": [
+        "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-Protection.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-Protection.html",
+      "referenceNumber": 57,
+      "name": "BSD Protection License",
+      "licenseId": "BSD-Protection",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AGPL-3.0.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./AGPL-3.0.html",
+      "referenceNumber": 58,
+      "name": "GNU Affero General Public License v3.0",
+      "licenseId": "AGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BUSL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BUSL-1.1.html",
+      "referenceNumber": 59,
+      "name": "Business Source License 1.1",
+      "licenseId": "BUSL-1.1",
+      "seeAlso": [
+        "https://mariadb.com/bsl11/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Artistic-1.0-Perl.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Artistic-1.0-Perl.html",
+      "referenceNumber": 60,
+      "name": "Artistic License 1.0 (Perl)",
+      "licenseId": "Artistic-1.0-Perl",
+      "seeAlso": [
+        "http://dev.perl.org/licenses/artistic.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSL-1.0.html",
+      "referenceNumber": 61,
+      "name": "Boost Software License 1.0",
+      "licenseId": "BSL-1.0",
+      "seeAlso": [
+        "http://www.boost.org/LICENSE_1_0.txt",
+        "https://opensource.org/licenses/BSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-2-Clause-Views.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-2-Clause-Views.html",
+      "referenceNumber": 62,
+      "name": "BSD 2-Clause with views sentence",
+      "licenseId": "BSD-2-Clause-Views",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/freebsd-license.html",
+        "https://people.freebsd.org/~ivoras/wine/patch-wine-nvidia.sh",
+        "https://github.com/protegeproject/protege/blob/master/license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CAL-1.0-Combined-Work-Exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CAL-1.0-Combined-Work-Exception.html",
+      "referenceNumber": 63,
+      "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
+      "licenseId": "CAL-1.0-Combined-Work-Exception",
+      "seeAlso": [
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CATOSL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CATOSL-1.1.html",
+      "referenceNumber": 64,
+      "name": "Computer Associates Trusted Open Source License 1.1",
+      "licenseId": "CATOSL-1.1",
+      "seeAlso": [
+        "https://opensource.org/licenses/CATOSL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./bzip2-1.0.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./bzip2-1.0.5.html",
+      "referenceNumber": 65,
+      "name": "bzip2 and libbzip2 License v1.0.5",
+      "licenseId": "bzip2-1.0.5",
+      "seeAlso": [
+        "https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./bzip2-1.0.6.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./bzip2-1.0.6.html",
+      "referenceNumber": 66,
+      "name": "bzip2 and libbzip2 License v1.0.6",
+      "licenseId": "bzip2-1.0.6",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dbzip2.git;a\u003dblob;f\u003dLICENSE;hb\u003dbzip2-1.0.6",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-2.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-2.5.html",
+      "referenceNumber": 67,
+      "name": "Creative Commons Attribution 2.5 Generic",
+      "licenseId": "CC-BY-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-3.0-AT.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-3.0-AT.html",
+      "referenceNumber": 68,
+      "name": "Creative Commons Attribution 3.0 Austria",
+      "licenseId": "CC-BY-3.0-AT",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/at/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./C-UDA-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./C-UDA-1.0.html",
+      "referenceNumber": 69,
+      "name": "Computational Use of Data Agreement v1.0",
+      "licenseId": "C-UDA-1.0",
+      "seeAlso": [
+        "https://github.com/microsoft/Computational-Use-of-Data-Agreement/blob/master/C-UDA-1.0.md",
+        "https://cdla.dev/computational-use-of-data-agreement-v1-0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-3.0-US.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-3.0-US.html",
+      "referenceNumber": 70,
+      "name": "Creative Commons Attribution 3.0 United States",
+      "licenseId": "CC-BY-3.0-US",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/us/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-1.0.html",
+      "referenceNumber": 71,
+      "name": "Creative Commons Attribution 1.0 Generic",
+      "licenseId": "CC-BY-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-1.0.html",
+      "referenceNumber": 72,
+      "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
+      "licenseId": "CC-BY-NC-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-2.0.html",
+      "referenceNumber": 73,
+      "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
+      "licenseId": "CC-BY-NC-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-2.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-2.5.html",
+      "referenceNumber": 74,
+      "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
+      "licenseId": "CC-BY-NC-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-2.0.html",
+      "referenceNumber": 75,
+      "name": "Creative Commons Attribution 2.0 Generic",
+      "licenseId": "CC-BY-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-4.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-4.0.html",
+      "referenceNumber": 76,
+      "name": "Creative Commons Attribution Non Commercial 4.0 International",
+      "licenseId": "CC-BY-NC-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-ND-1.0.html",
+      "referenceNumber": 77,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
+      "licenseId": "CC-BY-NC-ND-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-ND-2.0.html",
+      "referenceNumber": 78,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
+      "licenseId": "CC-BY-NC-ND-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-3.0.html",
+      "referenceNumber": 79,
+      "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
+      "licenseId": "CC-BY-NC-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-3.0-IGO.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-ND-3.0-IGO.html",
+      "referenceNumber": 80,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
+      "licenseId": "CC-BY-NC-ND-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-ND-3.0.html",
+      "referenceNumber": 81,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
+      "licenseId": "CC-BY-NC-ND-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-No-Nuclear-License.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-3-Clause-No-Nuclear-License.html",
+      "referenceNumber": 82,
+      "name": "BSD 3-Clause No Nuclear License",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License",
+      "seeAlso": [
+        "http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam\u003d1467140197_43d516ce1776bd08a58235a7785be1cc"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-4.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-ND-4.0.html",
+      "referenceNumber": 83,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
+      "licenseId": "CC-BY-NC-ND-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-SA-2.0.html",
+      "referenceNumber": 84,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
+      "licenseId": "CC-BY-NC-SA-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-2.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-SA-2.5.html",
+      "referenceNumber": 85,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
+      "licenseId": "CC-BY-NC-SA-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-SA-3.0.html",
+      "referenceNumber": 86,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
+      "licenseId": "CC-BY-NC-SA-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-4.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-SA-4.0.html",
+      "referenceNumber": 87,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
+      "licenseId": "CC-BY-NC-SA-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-ND-1.0.html",
+      "referenceNumber": 88,
+      "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
+      "licenseId": "CC-BY-ND-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-Clear.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-3-Clause-Clear.html",
+      "referenceNumber": 89,
+      "name": "BSD 3-Clause Clear License",
+      "licenseId": "BSD-3-Clause-Clear",
+      "seeAlso": [
+        "http://labs.metacarta.com/license-explanation.html#license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-2.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-ND-2.5.html",
+      "referenceNumber": 90,
+      "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
+      "licenseId": "CC-BY-ND-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-ND-3.0.html",
+      "referenceNumber": 91,
+      "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
+      "licenseId": "CC-BY-ND-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-4.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-ND-4.0.html",
+      "referenceNumber": 92,
+      "name": "Creative Commons Attribution No Derivatives 4.0 International",
+      "licenseId": "CC-BY-ND-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-SA-1.0.html",
+      "referenceNumber": 93,
+      "name": "Creative Commons Attribution Share Alike 1.0 Generic",
+      "licenseId": "CC-BY-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-2.0-UK.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-SA-2.0-UK.html",
+      "referenceNumber": 94,
+      "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
+      "licenseId": "CC-BY-SA-2.0-UK",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.0/uk/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-SA-2.0.html",
+      "referenceNumber": 95,
+      "name": "Creative Commons Attribution Share Alike 2.0 Generic",
+      "licenseId": "CC-BY-SA-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-2.1-JP.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-SA-2.1-JP.html",
+      "referenceNumber": 96,
+      "name": "Creative Commons Attribution Share Alike 2.1 Japan",
+      "licenseId": "CC-BY-SA-2.1-JP",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.1/jp/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-ND-2.0.html",
+      "referenceNumber": 97,
+      "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
+      "licenseId": "CC-BY-ND-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-3.0-AT.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-SA-3.0-AT.html",
+      "referenceNumber": 98,
+      "name": "Creative Commons Attribution-Share Alike 3.0 Austria",
+      "licenseId": "CC-BY-SA-3.0-AT",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/at/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-SA-3.0.html",
+      "referenceNumber": 99,
+      "name": "Creative Commons Attribution Share Alike 3.0 Unported",
+      "licenseId": "CC-BY-SA-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-4.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-SA-4.0.html",
+      "referenceNumber": 100,
+      "name": "Creative Commons Attribution Share Alike 4.0 International",
+      "licenseId": "CC-BY-SA-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-2.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-SA-2.5.html",
+      "referenceNumber": 101,
+      "name": "Creative Commons Attribution Share Alike 2.5 Generic",
+      "licenseId": "CC-BY-SA-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-3.0.html",
+      "referenceNumber": 102,
+      "name": "Creative Commons Attribution 3.0 Unported",
+      "licenseId": "CC-BY-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CDDL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CDDL-1.0.html",
+      "referenceNumber": 103,
+      "name": "Common Development and Distribution License 1.0",
+      "licenseId": "CDDL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/cddl1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CC0-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC0-1.0.html",
+      "referenceNumber": 104,
+      "name": "Creative Commons Zero v1.0 Universal",
+      "licenseId": "CC0-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-2.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-ND-2.5.html",
+      "referenceNumber": 105,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
+      "licenseId": "CC-BY-NC-ND-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-NC-SA-1.0.html",
+      "referenceNumber": 106,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
+      "licenseId": "CC-BY-NC-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Caldera.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Caldera.html",
+      "referenceNumber": 107,
+      "name": "Caldera License",
+      "licenseId": "Caldera",
+      "seeAlso": [
+        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CDLA-Permissive-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CDLA-Permissive-1.0.html",
+      "referenceNumber": 108,
+      "name": "Community Data License Agreement Permissive 1.0",
+      "licenseId": "CDLA-Permissive-1.0",
+      "seeAlso": [
+        "https://cdla.io/permissive-1-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-4.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-BY-4.0.html",
+      "referenceNumber": 109,
+      "name": "Creative Commons Attribution 4.0 International",
+      "licenseId": "CC-BY-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-PDDC.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CC-PDDC.html",
+      "referenceNumber": 110,
+      "name": "Creative Commons Public Domain Dedication and Certification",
+      "licenseId": "CC-PDDC",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/publicdomain/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-4-Clause-UC.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-4-Clause-UC.html",
+      "referenceNumber": 111,
+      "name": "BSD-4-Clause (University of California-Specific)",
+      "licenseId": "BSD-4-Clause-UC",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-4-Clause.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./BSD-4-Clause.html",
+      "referenceNumber": 112,
+      "name": "BSD 4-Clause \"Original\" or \"Old\" License",
+      "licenseId": "BSD-4-Clause",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BSD_4Clause"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CAL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CAL-1.0.html",
+      "referenceNumber": 113,
+      "name": "Cryptographic Autonomy License 1.0",
+      "licenseId": "CAL-1.0",
+      "seeAlso": [
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CDDL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CDDL-1.1.html",
+      "referenceNumber": 114,
+      "name": "Common Development and Distribution License 1.1",
+      "licenseId": "CDDL-1.1",
+      "seeAlso": [
+        "http://glassfish.java.net/public/CDDL+GPL_1_1.html",
+        "https://javaee.github.io/glassfish/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-1.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CERN-OHL-1.2.html",
+      "referenceNumber": 115,
+      "name": "CERN Open Hardware Licence v1.2",
+      "licenseId": "CERN-OHL-1.2",
+      "seeAlso": [
+        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CERN-OHL-1.1.html",
+      "referenceNumber": 116,
+      "name": "CERN Open Hardware Licence v1.1",
+      "licenseId": "CERN-OHL-1.1",
+      "seeAlso": [
+        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-P-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CERN-OHL-P-2.0.html",
+      "referenceNumber": 117,
+      "name": "CERN Open Hardware Licence Version 2 - Permissive",
+      "licenseId": "CERN-OHL-P-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CERN-OHL-S-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CERN-OHL-S-2.0.html",
+      "referenceNumber": 118,
+      "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
+      "licenseId": "CERN-OHL-S-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CECILL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CECILL-1.1.html",
+      "referenceNumber": 119,
+      "name": "CeCILL Free Software License Agreement v1.1",
+      "licenseId": "CECILL-1.1",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CECILL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CECILL-2.0.html",
+      "referenceNumber": 120,
+      "name": "CeCILL Free Software License Agreement v2.0",
+      "licenseId": "CECILL-2.0",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CECILL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CECILL-1.0.html",
+      "referenceNumber": 121,
+      "name": "CeCILL Free Software License Agreement v1.0",
+      "licenseId": "CECILL-1.0",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CNRI-Python.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CNRI-Python.html",
+      "referenceNumber": 122,
+      "name": "CNRI Python License",
+      "licenseId": "CNRI-Python",
+      "seeAlso": [
+        "https://opensource.org/licenses/CNRI-Python"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CNRI-Python-GPL-Compatible.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CNRI-Python-GPL-Compatible.html",
+      "referenceNumber": 123,
+      "name": "CNRI Python Open Source GPL Compatible License Agreement",
+      "licenseId": "CNRI-Python-GPL-Compatible",
+      "seeAlso": [
+        "http://www.python.org/download/releases/1.6.1/download_win/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./copyleft-next-0.3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./copyleft-next-0.3.0.html",
+      "referenceNumber": 124,
+      "name": "copyleft-next 0.3.0",
+      "licenseId": "copyleft-next-0.3.0",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CPAL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CPAL-1.0.html",
+      "referenceNumber": 125,
+      "name": "Common Public Attribution License 1.0",
+      "licenseId": "CPAL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CPAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./copyleft-next-0.3.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./copyleft-next-0.3.1.html",
+      "referenceNumber": 126,
+      "name": "copyleft-next 0.3.1",
+      "licenseId": "copyleft-next-0.3.1",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CPL-1.0.html",
+      "referenceNumber": 127,
+      "name": "Common Public License 1.0",
+      "licenseId": "CPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ClArtistic.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ClArtistic.html",
+      "referenceNumber": 128,
+      "name": "Clarified Artistic License",
+      "licenseId": "ClArtistic",
+      "seeAlso": [
+        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
+        "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CECILL-C.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CECILL-C.html",
+      "referenceNumber": 129,
+      "name": "CeCILL-C Free Software License Agreement",
+      "licenseId": "CECILL-C",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CNRI-Jython.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CNRI-Jython.html",
+      "referenceNumber": 130,
+      "name": "CNRI Jython License",
+      "licenseId": "CNRI-Jython",
+      "seeAlso": [
+        "http://www.jython.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Condor-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Condor-1.1.html",
+      "referenceNumber": 131,
+      "name": "Condor Public License v1.1",
+      "licenseId": "Condor-1.1",
+      "seeAlso": [
+        "http://research.cs.wisc.edu/condor/license.html#condor",
+        "http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CPOL-1.02.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CPOL-1.02.html",
+      "referenceNumber": 132,
+      "name": "Code Project Open License 1.02",
+      "licenseId": "CPOL-1.02",
+      "seeAlso": [
+        "http://www.codeproject.com/info/cpol10.aspx"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./curl.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./curl.html",
+      "referenceNumber": 133,
+      "name": "curl License",
+      "licenseId": "curl",
+      "seeAlso": [
+        "https://github.com/bagder/curl/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./diffmark.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./diffmark.html",
+      "referenceNumber": 134,
+      "name": "diffmark license",
+      "licenseId": "diffmark",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/diffmark"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Crossword.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Crossword.html",
+      "referenceNumber": 135,
+      "name": "Crossword License",
+      "licenseId": "Crossword",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Crossword"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Dotseqn.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Dotseqn.html",
+      "referenceNumber": 136,
+      "name": "Dotseqn License",
+      "licenseId": "Dotseqn",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Dotseqn"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./DOC.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./DOC.html",
+      "referenceNumber": 137,
+      "name": "DOC License",
+      "licenseId": "DOC",
+      "seeAlso": [
+        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html",
+        "https://www.dre.vanderbilt.edu/~schmidt/ACE-copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./DSDP.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./DSDP.html",
+      "referenceNumber": 138,
+      "name": "DSDP License",
+      "licenseId": "DSDP",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/DSDP"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./DRL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./DRL-1.0.html",
+      "referenceNumber": 139,
+      "name": "Detection Rule License 1.0",
+      "licenseId": "DRL-1.0",
+      "seeAlso": [
+        "https://github.com/Neo23x0/sigma/blob/master/LICENSE.Detection.Rules.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ECL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ECL-1.0.html",
+      "referenceNumber": 140,
+      "name": "Educational Community License v1.0",
+      "licenseId": "ECL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/ECL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ECL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ECL-2.0.html",
+      "referenceNumber": 141,
+      "name": "Educational Community License v2.0",
+      "licenseId": "ECL-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/ECL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./eCos-2.0.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./eCos-2.0.html",
+      "referenceNumber": 142,
+      "name": "eCos license version 2.0",
+      "licenseId": "eCos-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/ecos-license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CrystalStacker.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CrystalStacker.html",
+      "referenceNumber": 143,
+      "name": "CrystalStacker License",
+      "licenseId": "CrystalStacker",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd\u003dLicensing/CrystalStacker"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-W-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CERN-OHL-W-2.0.html",
+      "referenceNumber": 144,
+      "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
+      "licenseId": "CERN-OHL-W-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./D-FSL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./D-FSL-1.0.html",
+      "referenceNumber": 145,
+      "name": "Deutsche Freie Software Lizenz",
+      "licenseId": "D-FSL-1.0",
+      "seeAlso": [
+        "http://www.dipp.nrw.de/d-fsl/lizenzen/",
+        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/de/D-FSL-1_0_de.txt",
+        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/en/D-FSL-1_0_en.txt",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/deutsche-freie-software-lizenz",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/german-free-software-license",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_de.txt/at_download/file",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_en.txt/at_download/file"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./eGenix.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./eGenix.html",
+      "referenceNumber": 146,
+      "name": "eGenix.com Public License 1.1.0",
+      "licenseId": "eGenix",
+      "seeAlso": [
+        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
+        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./EPICS.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./EPICS.html",
+      "referenceNumber": 147,
+      "name": "EPICS Open License",
+      "licenseId": "EPICS",
+      "seeAlso": [
+        "https://epics.anl.gov/license/open.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Entessa.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Entessa.html",
+      "referenceNumber": 148,
+      "name": "Entessa Public License v1.0",
+      "licenseId": "Entessa",
+      "seeAlso": [
+        "https://opensource.org/licenses/Entessa"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./EPL-1.0.html",
+      "referenceNumber": 149,
+      "name": "Eclipse Public License 1.0",
+      "licenseId": "EPL-1.0",
+      "seeAlso": [
+        "http://www.eclipse.org/legal/epl-v10.html",
+        "https://opensource.org/licenses/EPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EFL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./EFL-2.0.html",
+      "referenceNumber": 150,
+      "name": "Eiffel Forum License v2.0",
+      "licenseId": "EFL-2.0",
+      "seeAlso": [
+        "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
+        "https://opensource.org/licenses/EFL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CUA-OPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CUA-OPL-1.0.html",
+      "referenceNumber": 151,
+      "name": "CUA Office Public License v1.0",
+      "licenseId": "CUA-OPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CUA-OPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./etalab-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./etalab-2.0.html",
+      "referenceNumber": 152,
+      "name": "Etalab Open License 2.0",
+      "licenseId": "etalab-2.0",
+      "seeAlso": [
+        "https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf",
+        "https://raw.githubusercontent.com/DISIC/politique-de-contribution-open-source/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./EUPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./EUPL-1.0.html",
+      "referenceNumber": 153,
+      "name": "European Union Public License 1.0",
+      "licenseId": "EUPL-1.0",
+      "seeAlso": [
+        "http://ec.europa.eu/idabc/en/document/7330.html",
+        "http://ec.europa.eu/idabc/servlets/Doc027f.pdf?id\u003d31096"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ErlPL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ErlPL-1.1.html",
+      "referenceNumber": 154,
+      "name": "Erlang Public License v1.1",
+      "licenseId": "ErlPL-1.1",
+      "seeAlso": [
+        "http://www.erlang.org/EPLICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./EUDatagrid.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./EUDatagrid.html",
+      "referenceNumber": 155,
+      "name": "EU DataGrid Software License",
+      "licenseId": "EUDatagrid",
+      "seeAlso": [
+        "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
+        "https://opensource.org/licenses/EUDatagrid"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EUPL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./EUPL-1.1.html",
+      "referenceNumber": 156,
+      "name": "European Union Public License 1.1",
+      "licenseId": "EUPL-1.1",
+      "seeAlso": [
+        "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
+        "https://opensource.org/licenses/EUPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Cube.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Cube.html",
+      "referenceNumber": 157,
+      "name": "Cube License",
+      "licenseId": "Cube",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Cube"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./dvipdfm.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./dvipdfm.html",
+      "referenceNumber": 158,
+      "name": "dvipdfm License",
+      "licenseId": "dvipdfm",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FreeBSD-DOC.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./FreeBSD-DOC.html",
+      "referenceNumber": 159,
+      "name": "FreeBSD Documentation License",
+      "licenseId": "FreeBSD-DOC",
+      "seeAlso": [
+        "https://www.freebsd.org/copyright/freebsd-doc-license/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Eurosym.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Eurosym.html",
+      "referenceNumber": 160,
+      "name": "Eurosym License",
+      "licenseId": "Eurosym",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Eurosym"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FSFAP.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./FSFAP.html",
+      "referenceNumber": 161,
+      "name": "FSF All Permissive License",
+      "licenseId": "FSFAP",
+      "seeAlso": [
+        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FreeImage.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./FreeImage.html",
+      "referenceNumber": 162,
+      "name": "FreeImage Public License v1.0",
+      "licenseId": "FreeImage",
+      "seeAlso": [
+        "http://freeimage.sourceforge.net/freeimage-license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FSFULLR.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./FSFULLR.html",
+      "referenceNumber": 163,
+      "name": "FSF Unlimited License (with License Retention)",
+      "licenseId": "FSFULLR",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FSFUL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./FSFUL.html",
+      "referenceNumber": 164,
+      "name": "FSF Unlimited License",
+      "licenseId": "FSFUL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GD.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GD.html",
+      "referenceNumber": 165,
+      "name": "GD License",
+      "licenseId": "GD",
+      "seeAlso": [
+        "https://libgd.github.io/manuals/2.3.0/files/license-txt.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-invariants-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.1-invariants-only.html",
+      "referenceNumber": 166,
+      "name": "GNU Free Documentation License v1.1 only - invariants",
+      "licenseId": "GFDL-1.1-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./EUPL-1.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./EUPL-1.2.html",
+      "referenceNumber": 167,
+      "name": "European Union Public License 1.2",
+      "licenseId": "EUPL-1.2",
+      "seeAlso": [
+        "https://joinup.ec.europa.eu/page/eupl-text-11-12",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt",
+        "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
+        "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri\u003dCELEX:32017D0863",
+        "https://opensource.org/licenses/EUPL-1.2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EPL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./EPL-2.0.html",
+      "referenceNumber": 168,
+      "name": "Eclipse Public License 2.0",
+      "licenseId": "EPL-2.0",
+      "seeAlso": [
+        "https://www.eclipse.org/legal/epl-2.0",
+        "https://www.opensource.org/licenses/EPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GFDL-1.1-no-invariants-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.1-no-invariants-or-later.html",
+      "referenceNumber": 169,
+      "name": "GNU Free Documentation License v1.1 or later - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.1-only.html",
+      "referenceNumber": 170,
+      "name": "GNU Free Documentation License v1.1 only",
+      "licenseId": "GFDL-1.1-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.1-or-later.html",
+      "referenceNumber": 171,
+      "name": "GNU Free Documentation License v1.1 or later",
+      "licenseId": "GFDL-1.1-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GFDL-1.1.html",
+      "referenceNumber": 172,
+      "name": "GNU Free Documentation License v1.1",
+      "licenseId": "GFDL-1.1",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FTL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./FTL.html",
+      "referenceNumber": 173,
+      "name": "Freetype Project License",
+      "licenseId": "FTL",
+      "seeAlso": [
+        "http://freetype.fis.uniroma2.it/FTL.TXT",
+        "http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-invariants-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.2-invariants-or-later.html",
+      "referenceNumber": 174,
+      "name": "GNU Free Documentation License v1.2 or later - invariants",
+      "licenseId": "GFDL-1.2-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-invariants-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.1-invariants-or-later.html",
+      "referenceNumber": 175,
+      "name": "GNU Free Documentation License v1.1 or later - invariants",
+      "licenseId": "GFDL-1.1-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-invariants-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.2-invariants-only.html",
+      "referenceNumber": 176,
+      "name": "GNU Free Documentation License v1.2 only - invariants",
+      "licenseId": "GFDL-1.2-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.2-only.html",
+      "referenceNumber": 177,
+      "name": "GNU Free Documentation License v1.2 only",
+      "licenseId": "GFDL-1.2-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.2-or-later.html",
+      "referenceNumber": 178,
+      "name": "GNU Free Documentation License v1.2 or later",
+      "licenseId": "GFDL-1.2-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GFDL-1.2.html",
+      "referenceNumber": 179,
+      "name": "GNU Free Documentation License v1.2",
+      "licenseId": "GFDL-1.2",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-no-invariants-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.2-no-invariants-only.html",
+      "referenceNumber": 180,
+      "name": "GNU Free Documentation License v1.2 only - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-invariants-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.3-invariants-only.html",
+      "referenceNumber": 181,
+      "name": "GNU Free Documentation License v1.3 only - invariants",
+      "licenseId": "GFDL-1.3-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-no-invariants-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.3-no-invariants-only.html",
+      "referenceNumber": 182,
+      "name": "GNU Free Documentation License v1.3 only - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-invariants-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.3-invariants-or-later.html",
+      "referenceNumber": 183,
+      "name": "GNU Free Documentation License v1.3 or later - invariants",
+      "licenseId": "GFDL-1.3-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-no-invariants-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.2-no-invariants-or-later.html",
+      "referenceNumber": 184,
+      "name": "GNU Free Documentation License v1.2 or later - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Fair.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Fair.html",
+      "referenceNumber": 185,
+      "name": "Fair License",
+      "licenseId": "Fair",
+      "seeAlso": [
+        "http://fairlicense.org/",
+        "https://opensource.org/licenses/Fair"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Frameworx-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Frameworx-1.0.html",
+      "referenceNumber": 186,
+      "name": "Frameworx Open License 1.0",
+      "licenseId": "Frameworx-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Frameworx-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Giftware.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Giftware.html",
+      "referenceNumber": 187,
+      "name": "Giftware License",
+      "licenseId": "Giftware",
+      "seeAlso": [
+        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-no-invariants-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.1-no-invariants-only.html",
+      "referenceNumber": 188,
+      "name": "GNU Free Documentation License v1.1 only - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GL2PS.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GL2PS.html",
+      "referenceNumber": 189,
+      "name": "GL2PS License",
+      "licenseId": "GL2PS",
+      "seeAlso": [
+        "http://www.geuz.org/gl2ps/COPYING.GL2PS"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Glulxe.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Glulxe.html",
+      "referenceNumber": 190,
+      "name": "Glulxe License",
+      "licenseId": "Glulxe",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Glulxe"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Glide.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Glide.html",
+      "referenceNumber": 191,
+      "name": "3dfx Glide License",
+      "licenseId": "Glide",
+      "seeAlso": [
+        "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./gnuplot.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./gnuplot.html",
+      "referenceNumber": 192,
+      "name": "gnuplot License",
+      "licenseId": "gnuplot",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GLWTPL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GLWTPL.html",
+      "referenceNumber": 193,
+      "name": "Good Luck With That Public License",
+      "licenseId": "GLWTPL",
+      "seeAlso": [
+        "https://github.com/me-shaon/GLWTPL/commit/da5f6bc734095efbacb442c0b31e33a65b9d6e85"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GPL-1.0-only.html",
+      "referenceNumber": 194,
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GPL-1.0-or-later.html",
+      "referenceNumber": 195,
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-1.0.html",
+      "referenceNumber": 196,
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.3-only.html",
+      "referenceNumber": 197,
+      "name": "GNU Free Documentation License v1.3 only",
+      "licenseId": "GFDL-1.3-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GPL-2.0-only.html",
+      "referenceNumber": 198,
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-2.0-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GPL-2.0-or-later.html",
+      "referenceNumber": 199,
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-2.0-with-autoconf-exception.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-2.0-with-autoconf-exception.html",
+      "referenceNumber": 200,
+      "name": "GNU General Public License v2.0 w/Autoconf exception",
+      "licenseId": "GPL-2.0-with-autoconf-exception",
+      "seeAlso": [
+        "http://ac-archive.sourceforge.net/doc/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0+.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-2.0+.html",
+      "referenceNumber": 201,
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GFDL-1.3.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GFDL-1.3.html",
+      "referenceNumber": 202,
+      "name": "GNU Free Documentation License v1.3",
+      "licenseId": "GFDL-1.3",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0+.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-1.0+.html",
+      "referenceNumber": 203,
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CDLA-Sharing-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CDLA-Sharing-1.0.html",
+      "referenceNumber": 204,
+      "name": "Community Data License Agreement Sharing 1.0",
+      "licenseId": "CDLA-Sharing-1.0",
+      "seeAlso": [
+        "https://cdla.io/sharing-1-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-classpath-exception.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-2.0-with-classpath-exception.html",
+      "referenceNumber": 205,
+      "name": "GNU General Public License v2.0 w/Classpath exception",
+      "licenseId": "GPL-2.0-with-classpath-exception",
+      "seeAlso": [
+        "https://www.gnu.org/software/classpath/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-GCC-exception.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-2.0-with-GCC-exception.html",
+      "referenceNumber": 206,
+      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-2.0-with-GCC-exception",
+      "seeAlso": [
+        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-bison-exception.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-2.0-with-bison-exception.html",
+      "referenceNumber": 207,
+      "name": "GNU General Public License v2.0 w/Bison exception",
+      "licenseId": "GPL-2.0-with-bison-exception",
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id\u003d193d7c7054ba7197b0789e14965b739162319b5e#n141"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-font-exception.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-2.0-with-font-exception.html",
+      "referenceNumber": 208,
+      "name": "GNU General Public License v2.0 w/Font exception",
+      "licenseId": "GPL-2.0-with-font-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.html#FontException"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-2.0.html",
+      "referenceNumber": 209,
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CECILL-2.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CECILL-2.1.html",
+      "referenceNumber": 210,
+      "name": "CeCILL Free Software License Agreement v2.1",
+      "licenseId": "CECILL-2.1",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-3.0.html",
+      "referenceNumber": 211,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0+.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-3.0+.html",
+      "referenceNumber": 212,
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-with-autoconf-exception.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-3.0-with-autoconf-exception.html",
+      "referenceNumber": 213,
+      "name": "GNU General Public License v3.0 w/Autoconf exception",
+      "licenseId": "GPL-3.0-with-autoconf-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/autoconf-exception-3.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-3.0-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GPL-3.0-only.html",
+      "referenceNumber": 214,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Hippocratic-2.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Hippocratic-2.1.html",
+      "referenceNumber": 215,
+      "name": "Hippocratic License 2.1",
+      "licenseId": "Hippocratic-2.1",
+      "seeAlso": [
+        "https://firstdonoharm.dev/version/2/1/license.html",
+        "https://github.com/EthicalSource/hippocratic-license/blob/58c0e646d64ff6fbee275bfe2b9492f914e3ab2a/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./HPND.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./HPND.html",
+      "referenceNumber": 216,
+      "name": "Historical Permission Notice and Disclaimer",
+      "licenseId": "HPND",
+      "seeAlso": [
+        "https://opensource.org/licenses/HPND"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./HTMLTIDY.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./HTMLTIDY.html",
+      "referenceNumber": 217,
+      "name": "HTML Tidy License",
+      "licenseId": "HTMLTIDY",
+      "seeAlso": [
+        "https://github.com/htacg/tidy-html5/blob/next/README/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-3.0-with-GCC-exception.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./GPL-3.0-with-GCC-exception.html",
+      "referenceNumber": 218,
+      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-3.0-with-GCC-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gcc-exception-3.1.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./HaskellReport.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./HaskellReport.html",
+      "referenceNumber": 219,
+      "name": "Haskell Language Report License",
+      "licenseId": "HaskellReport",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-3.0-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GPL-3.0-or-later.html",
+      "referenceNumber": 220,
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ICU.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ICU.html",
+      "referenceNumber": 221,
+      "name": "ICU License",
+      "licenseId": "ICU",
+      "seeAlso": [
+        "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ImageMagick.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ImageMagick.html",
+      "referenceNumber": 222,
+      "name": "ImageMagick License",
+      "licenseId": "ImageMagick",
+      "seeAlso": [
+        "http://www.imagemagick.org/script/license.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./iMatix.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./iMatix.html",
+      "referenceNumber": 223,
+      "name": "iMatix Standard Function Library Agreement",
+      "licenseId": "iMatix",
+      "seeAlso": [
+        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./IBM-pibs.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./IBM-pibs.html",
+      "referenceNumber": 224,
+      "name": "IBM PowerPC Initialization and Boot Software",
+      "licenseId": "IBM-pibs",
+      "seeAlso": [
+        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003darch/powerpc/cpu/ppc4xx/miiphy.c;h\u003d297155fdafa064b955e53e9832de93bfb0cfb85b;hb\u003d9fab4bf4cc077c21e43941866f3f2c196f28670d"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Intel-ACPI.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Intel-ACPI.html",
+      "referenceNumber": 225,
+      "name": "Intel ACPI Software License Agreement",
+      "licenseId": "Intel-ACPI",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Intel.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Intel.html",
+      "referenceNumber": 226,
+      "name": "Intel Open Source License",
+      "licenseId": "Intel",
+      "seeAlso": [
+        "https://opensource.org/licenses/Intel"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Info-ZIP.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Info-ZIP.html",
+      "referenceNumber": 227,
+      "name": "Info-ZIP License",
+      "licenseId": "Info-ZIP",
+      "seeAlso": [
+        "http://www.info-zip.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./IPA.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./IPA.html",
+      "referenceNumber": 228,
+      "name": "IPA Font License",
+      "licenseId": "IPA",
+      "seeAlso": [
+        "https://opensource.org/licenses/IPA"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./IJG.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./IJG.html",
+      "referenceNumber": 229,
+      "name": "Independent JPEG Group License",
+      "licenseId": "IJG",
+      "seeAlso": [
+        "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev\u003d1.2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ISC.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ISC.html",
+      "referenceNumber": 230,
+      "name": "ISC License",
+      "licenseId": "ISC",
+      "seeAlso": [
+        "https://www.isc.org/downloads/software-support-policy/isc-license/",
+        "https://opensource.org/licenses/ISC"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./JasPer-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./JasPer-2.0.html",
+      "referenceNumber": 231,
+      "name": "JasPer License",
+      "licenseId": "JasPer-2.0",
+      "seeAlso": [
+        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./JPNIC.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./JPNIC.html",
+      "referenceNumber": 232,
+      "name": "Japan Network Information Center License",
+      "licenseId": "JPNIC",
+      "seeAlso": [
+        "https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./JSON.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./JSON.html",
+      "referenceNumber": 233,
+      "name": "JSON License",
+      "licenseId": "JSON",
+      "seeAlso": [
+        "http://www.json.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LAL-1.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LAL-1.2.html",
+      "referenceNumber": 234,
+      "name": "Licence Art Libre 1.2",
+      "licenseId": "LAL-1.2",
+      "seeAlso": [
+        "http://artlibre.org/licence/lal/licence-art-libre-12/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LAL-1.3.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LAL-1.3.html",
+      "referenceNumber": 235,
+      "name": "Licence Art Libre 1.3",
+      "licenseId": "LAL-1.3",
+      "seeAlso": [
+        "https://artlibre.org/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Latex2e.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Latex2e.html",
+      "referenceNumber": 236,
+      "name": "Latex2e License",
+      "licenseId": "Latex2e",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Latex2e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Leptonica.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Leptonica.html",
+      "referenceNumber": 237,
+      "name": "Leptonica License",
+      "licenseId": "Leptonica",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Leptonica"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./HPND-sell-variant.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./HPND-sell-variant.html",
+      "referenceNumber": 238,
+      "name": "Historical Permission Notice and Disclaimer - sell variant",
+      "licenseId": "HPND-sell-variant",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LGPL-2.0-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LGPL-2.0-only.html",
+      "referenceNumber": 239,
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.0-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LGPL-2.0-or-later.html",
+      "referenceNumber": 240,
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Imlib2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Imlib2.html",
+      "referenceNumber": 241,
+      "name": "Imlib2 License",
+      "licenseId": "Imlib2",
+      "seeAlso": [
+        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
+        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./IPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./IPL-1.0.html",
+      "referenceNumber": 242,
+      "name": "IBM Public License v1.0",
+      "licenseId": "IPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/IPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LGPL-2.1-only.html",
+      "referenceNumber": 243,
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LGPL-2.1-or-later.html",
+      "referenceNumber": 244,
+      "name": "GNU Lesser General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.0+.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./LGPL-2.0+.html",
+      "referenceNumber": 245,
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.0.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./LGPL-2.0.html",
+      "referenceNumber": 246,
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CECILL-B.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CECILL-B.html",
+      "referenceNumber": 247,
+      "name": "CeCILL-B Free Software License Agreement",
+      "licenseId": "CECILL-B",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LGPL-3.0-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LGPL-3.0-or-later.html",
+      "referenceNumber": 248,
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0-only.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LGPL-3.0-only.html",
+      "referenceNumber": 249,
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPLLR.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LGPLLR.html",
+      "referenceNumber": 250,
+      "name": "Lesser General Public License For Linguistic Resources",
+      "licenseId": "LGPLLR",
+      "seeAlso": [
+        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./libpng-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./libpng-2.0.html",
+      "referenceNumber": 251,
+      "name": "PNG Reference Library version 2",
+      "licenseId": "libpng-2.0",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Libpng.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Libpng.html",
+      "referenceNumber": 252,
+      "name": "libpng License",
+      "licenseId": "Libpng",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./libselinux-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./libselinux-1.0.html",
+      "referenceNumber": 253,
+      "name": "libselinux public domain notice",
+      "licenseId": "libselinux-1.0",
+      "seeAlso": [
+        "https://github.com/SELinuxProject/selinux/blob/master/libselinux/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LGPL-3.0+.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./LGPL-3.0+.html",
+      "referenceNumber": 254,
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EFL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./EFL-1.0.html",
+      "referenceNumber": 255,
+      "name": "Eiffel Forum License v1.0",
+      "licenseId": "EFL-1.0",
+      "seeAlso": [
+        "http://www.eiffel-nice.org/license/forum.txt",
+        "https://opensource.org/licenses/EFL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./libtiff.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./libtiff.html",
+      "referenceNumber": 256,
+      "name": "libtiff License",
+      "licenseId": "libtiff",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/libtiff"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-no-invariants-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.3-no-invariants-or-later.html",
+      "referenceNumber": 257,
+      "name": "GNU Free Documentation License v1.3 or later - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LiLiQ-Rplus-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LiLiQ-Rplus-1.1.html",
+      "referenceNumber": 258,
+      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
+      "licenseId": "LiLiQ-Rplus-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LiLiQ-R-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LiLiQ-R-1.1.html",
+      "referenceNumber": 259,
+      "name": "Licence Libre du Québec – Réciprocité version 1.1",
+      "licenseId": "LiLiQ-R-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-R-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LPL-1.0.html",
+      "referenceNumber": 260,
+      "name": "Lucent Public License Version 1.0",
+      "licenseId": "LPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/LPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LiLiQ-P-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LiLiQ-P-1.1.html",
+      "referenceNumber": 261,
+      "name": "Licence Libre du Québec – Permissive version 1.1",
+      "licenseId": "LiLiQ-P-1.1",
+      "seeAlso": [
+        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-P-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Linux-OpenIB.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Linux-OpenIB.html",
+      "referenceNumber": 262,
+      "name": "Linux Kernel Variant of OpenIB.org license",
+      "licenseId": "Linux-OpenIB",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LPPL-1.0.html",
+      "referenceNumber": 263,
+      "name": "LaTeX Project Public License v1.0",
+      "licenseId": "LPPL-1.0",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LPPL-1.2.html",
+      "referenceNumber": 264,
+      "name": "LaTeX Project Public License v1.2",
+      "licenseId": "LPPL-1.2",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.3a.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LPPL-1.3a.html",
+      "referenceNumber": 265,
+      "name": "LaTeX Project Public License v1.3a",
+      "licenseId": "LPPL-1.3a",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPL-1.02.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LPL-1.02.html",
+      "referenceNumber": 266,
+      "name": "Lucent Public License v1.02",
+      "licenseId": "LPL-1.02",
+      "seeAlso": [
+        "http://plan9.bell-labs.com/plan9/license.html",
+        "https://opensource.org/licenses/LPL-1.02"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LPPL-1.3c.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LPPL-1.3c.html",
+      "referenceNumber": 267,
+      "name": "LaTeX Project Public License v1.3c",
+      "licenseId": "LPPL-1.3c",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
+        "https://opensource.org/licenses/LPPL-1.3c"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MakeIndex.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MakeIndex.html",
+      "referenceNumber": 268,
+      "name": "MakeIndex License",
+      "licenseId": "MakeIndex",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LGPL-2.1+.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./LGPL-2.1+.html",
+      "referenceNumber": 269,
+      "name": "GNU Library General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LPPL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LPPL-1.1.html",
+      "referenceNumber": 270,
+      "name": "LaTeX Project Public License v1.1",
+      "licenseId": "LPPL-1.1",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-CMU.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MIT-CMU.html",
+      "referenceNumber": 271,
+      "name": "CMU License",
+      "licenseId": "MIT-CMU",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style",
+        "https://github.com/python-pillow/Pillow/blob/fffb426092c8db24a5f4b6df243a8a3c01fb63cd/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MirOS.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MirOS.html",
+      "referenceNumber": 272,
+      "name": "The MirOS Licence",
+      "licenseId": "MirOS",
+      "seeAlso": [
+        "https://opensource.org/licenses/MirOS"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MIT-advertising.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MIT-advertising.html",
+      "referenceNumber": 273,
+      "name": "Enlightenment License (e16)",
+      "licenseId": "MIT-advertising",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-Modern-Variant.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MIT-Modern-Variant.html",
+      "referenceNumber": 274,
+      "name": "MIT License Modern Variant",
+      "licenseId": "MIT-Modern-Variant",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT#Modern_Variants",
+        "https://ptolemy.berkeley.edu/copyright.htm",
+        "https://pirlwww.lpl.arizona.edu/resources/guide/software/PerlTk/Tixlic.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MIT.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MIT.html",
+      "referenceNumber": 275,
+      "name": "MIT License",
+      "licenseId": "MIT",
+      "seeAlso": [
+        "https://opensource.org/licenses/MIT"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MIT-enna.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MIT-enna.html",
+      "referenceNumber": 276,
+      "name": "enna License",
+      "licenseId": "MIT-enna",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#enna"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-open-group.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MIT-open-group.html",
+      "referenceNumber": 277,
+      "name": "MIT Open Group variant",
+      "licenseId": "MIT-open-group",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xvinfo/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xsetroot/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xauth/-/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-feh.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MIT-feh.html",
+      "referenceNumber": 278,
+      "name": "feh License",
+      "licenseId": "MIT-feh",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#feh"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MITNFA.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MITNFA.html",
+      "referenceNumber": 279,
+      "name": "MIT +no-false-attribs license",
+      "licenseId": "MITNFA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MITNFA"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MPL-1.0.html",
+      "referenceNumber": 280,
+      "name": "Mozilla Public License 1.0",
+      "licenseId": "MPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.0.html",
+        "https://opensource.org/licenses/MPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./mpich2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./mpich2.html",
+      "referenceNumber": 281,
+      "name": "mpich2 License",
+      "licenseId": "mpich2",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MPL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MPL-2.0.html",
+      "referenceNumber": 282,
+      "name": "Mozilla Public License 2.0",
+      "licenseId": "MPL-2.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/2.0/",
+        "https://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MPL-2.0-no-copyleft-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MPL-2.0-no-copyleft-exception.html",
+      "referenceNumber": 283,
+      "name": "Mozilla Public License 2.0 (no copyleft exception)",
+      "licenseId": "MPL-2.0-no-copyleft-exception",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/2.0/",
+        "https://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MS-RL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MS-RL.html",
+      "referenceNumber": 284,
+      "name": "Microsoft Reciprocal License",
+      "licenseId": "MS-RL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "https://opensource.org/licenses/MS-RL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MTLL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MTLL.html",
+      "referenceNumber": 285,
+      "name": "Matrix Template Library License",
+      "licenseId": "MTLL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MPL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MPL-1.1.html",
+      "referenceNumber": 286,
+      "name": "Mozilla Public License 1.1",
+      "licenseId": "MPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.1.html",
+        "https://opensource.org/licenses/MPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MulanPSL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MulanPSL-2.0.html",
+      "referenceNumber": 287,
+      "name": "Mulan Permissive Software License, Version 2",
+      "licenseId": "MulanPSL-2.0",
+      "seeAlso": [
+        "https://license.coscl.org.cn/MulanPSL2/"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Motosoto.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Motosoto.html",
+      "referenceNumber": 288,
+      "name": "Motosoto License",
+      "licenseId": "Motosoto",
+      "seeAlso": [
+        "https://opensource.org/licenses/Motosoto"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Mup.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Mup.html",
+      "referenceNumber": 289,
+      "name": "Mup License",
+      "licenseId": "Mup",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Mup"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MulanPSL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MulanPSL-1.0.html",
+      "referenceNumber": 290,
+      "name": "Mulan Permissive Software License, Version 1",
+      "licenseId": "MulanPSL-1.0",
+      "seeAlso": [
+        "https://license.coscl.org.cn/MulanPSL/",
+        "https://github.com/yuwenlong/longphp/blob/25dfb70cc2a466dc4bb55ba30901cbce08d164b5/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NAIST-2003.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NAIST-2003.html",
+      "referenceNumber": 291,
+      "name": "Nara Institute of Science and Technology License (2003)",
+      "licenseId": "NAIST-2003",
+      "seeAlso": [
+        "https://enterprise.dejacode.com/licenses/public/naist-2003/#license-text",
+        "https://github.com/nodejs/node/blob/4a19cc8947b1bba2b2d27816ec3d0edf9b28e503/LICENSE#L343"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Naumen.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Naumen.html",
+      "referenceNumber": 292,
+      "name": "Naumen Public License",
+      "licenseId": "Naumen",
+      "seeAlso": [
+        "https://opensource.org/licenses/Naumen"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Multics.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Multics.html",
+      "referenceNumber": 293,
+      "name": "Multics License",
+      "licenseId": "Multics",
+      "seeAlso": [
+        "https://opensource.org/licenses/Multics"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NBPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NBPL-1.0.html",
+      "referenceNumber": 294,
+      "name": "Net Boolean Public License v1",
+      "licenseId": "NBPL-1.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NCSA.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NCSA.html",
+      "referenceNumber": 295,
+      "name": "University of Illinois/NCSA Open Source License",
+      "licenseId": "NCSA",
+      "seeAlso": [
+        "http://otm.illinois.edu/uiuc_openSource",
+        "https://opensource.org/licenses/NCSA"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Net-SNMP.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Net-SNMP.html",
+      "referenceNumber": 296,
+      "name": "Net-SNMP License",
+      "licenseId": "Net-SNMP",
+      "seeAlso": [
+        "http://net-snmp.sourceforge.net/about/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NetCDF.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NetCDF.html",
+      "referenceNumber": 297,
+      "name": "NetCDF license",
+      "licenseId": "NetCDF",
+      "seeAlso": [
+        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NASA-1.3.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NASA-1.3.html",
+      "referenceNumber": 298,
+      "name": "NASA Open Source Agreement 1.3",
+      "licenseId": "NASA-1.3",
+      "seeAlso": [
+        "http://ti.arc.nasa.gov/opensource/nosa/",
+        "https://opensource.org/licenses/NASA-1.3"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NGPL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NGPL.html",
+      "referenceNumber": 299,
+      "name": "Nethack General Public License",
+      "licenseId": "NGPL",
+      "seeAlso": [
+        "https://opensource.org/licenses/NGPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NIST-PD-fallback.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NIST-PD-fallback.html",
+      "referenceNumber": 300,
+      "name": "NIST Public Domain Notice with license fallback",
+      "licenseId": "NIST-PD-fallback",
+      "seeAlso": [
+        "https://github.com/usnistgov/jsip/blob/59700e6926cbe96c5cdae897d9a7d2656b42abe3/LICENSE",
+        "https://github.com/usnistgov/fipy/blob/86aaa5c2ba2c6f1be19593c5986071cf6568cc34/LICENSE.rst"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NIST-PD.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NIST-PD.html",
+      "referenceNumber": 301,
+      "name": "NIST Public Domain Notice",
+      "licenseId": "NIST-PD",
+      "seeAlso": [
+        "https://github.com/tcheneau/simpleRPL/blob/e645e69e38dd4e3ccfeceb2db8cba05b7c2e0cd3/LICENSE.txt",
+        "https://github.com/tcheneau/Routing/blob/f09f46fcfe636107f22f2c98348188a65a135d98/README.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Newsletr.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Newsletr.html",
+      "referenceNumber": 302,
+      "name": "Newsletr License",
+      "licenseId": "Newsletr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Newsletr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NLPL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NLPL.html",
+      "referenceNumber": 303,
+      "name": "No Limit Public License",
+      "licenseId": "NLPL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/NLPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Nokia.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Nokia.html",
+      "referenceNumber": 304,
+      "name": "Nokia Open Source License",
+      "licenseId": "Nokia",
+      "seeAlso": [
+        "https://opensource.org/licenses/nokia"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NOSL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NOSL.html",
+      "referenceNumber": 305,
+      "name": "Netizen Open Source License",
+      "licenseId": "NOSL",
+      "seeAlso": [
+        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Noweb.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Noweb.html",
+      "referenceNumber": 306,
+      "name": "Noweb License",
+      "licenseId": "Noweb",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Noweb"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NLOD-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NLOD-1.0.html",
+      "referenceNumber": 307,
+      "name": "Norwegian Licence for Open Government Data",
+      "licenseId": "NLOD-1.0",
+      "seeAlso": [
+        "http://data.norge.no/nlod/en/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NPL-1.0.html",
+      "referenceNumber": 308,
+      "name": "Netscape Public License v1.0",
+      "licenseId": "NPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NCGL-UK-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NCGL-UK-2.0.html",
+      "referenceNumber": 309,
+      "name": "Non-Commercial Government Licence",
+      "licenseId": "NCGL-UK-2.0",
+      "seeAlso": [
+        "https://github.com/spdx/license-list-XML/blob/master/src/Apache-2.0.xml"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NRL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NRL.html",
+      "referenceNumber": 310,
+      "name": "NRL License",
+      "licenseId": "NRL",
+      "seeAlso": [
+        "http://web.mit.edu/network/isakmp/nrllicense.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NTP-0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NTP-0.html",
+      "referenceNumber": 311,
+      "name": "NTP No Attribution",
+      "licenseId": "NTP-0",
+      "seeAlso": [
+        "https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NTP.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NTP.html",
+      "referenceNumber": 312,
+      "name": "NTP License",
+      "licenseId": "NTP",
+      "seeAlso": [
+        "https://opensource.org/licenses/NTP"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GFDL-1.3-or-later.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GFDL-1.3-or-later.html",
+      "referenceNumber": 313,
+      "name": "GNU Free Documentation License v1.3 or later",
+      "licenseId": "GFDL-1.3-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Nunit.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./Nunit.html",
+      "referenceNumber": 314,
+      "name": "Nunit License",
+      "licenseId": "Nunit",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Nunit"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./O-UDA-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./O-UDA-1.0.html",
+      "referenceNumber": 315,
+      "name": "Open Use of Data Agreement v1.0",
+      "licenseId": "O-UDA-1.0",
+      "seeAlso": [
+        "https://github.com/microsoft/Open-Use-of-Data-Agreement/blob/v1.0/O-UDA-1.0.md",
+        "https://cdla.dev/open-use-of-data-agreement-v1-0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NPL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NPL-1.1.html",
+      "referenceNumber": 316,
+      "name": "Netscape Public License v1.1",
+      "licenseId": "NPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.1/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OCCT-PL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OCCT-PL.html",
+      "referenceNumber": 317,
+      "name": "Open CASCADE Technology Public License",
+      "licenseId": "OCCT-PL",
+      "seeAlso": [
+        "http://www.opencascade.com/content/occt-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ODC-By-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ODC-By-1.0.html",
+      "referenceNumber": 318,
+      "name": "Open Data Commons Attribution License v1.0",
+      "licenseId": "ODC-By-1.0",
+      "seeAlso": [
+        "https://opendatacommons.org/licenses/by/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OFL-1.0-no-RFN.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OFL-1.0-no-RFN.html",
+      "referenceNumber": 319,
+      "name": "SIL Open Font License 1.0 with no Reserved Font Name",
+      "licenseId": "OFL-1.0-no-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OCLC-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OCLC-2.0.html",
+      "referenceNumber": 320,
+      "name": "OCLC Research Public License 2.0",
+      "licenseId": "OCLC-2.0",
+      "seeAlso": [
+        "http://www.oclc.org/research/activities/software/license/v2final.htm",
+        "https://opensource.org/licenses/OCLC-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OFL-1.0-RFN.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OFL-1.0-RFN.html",
+      "referenceNumber": 321,
+      "name": "SIL Open Font License 1.0 with Reserved Font Name",
+      "licenseId": "OFL-1.0-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OFL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OFL-1.0.html",
+      "referenceNumber": 322,
+      "name": "SIL Open Font License 1.0",
+      "licenseId": "OFL-1.0",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OFL-1.1-no-RFN.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OFL-1.1-no-RFN.html",
+      "referenceNumber": 323,
+      "name": "SIL Open Font License 1.1 with no Reserved Font Name",
+      "licenseId": "OFL-1.1-no-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OFL-1.1-RFN.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OFL-1.1-RFN.html",
+      "referenceNumber": 324,
+      "name": "SIL Open Font License 1.1 with Reserved Font Name",
+      "licenseId": "OFL-1.1-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OFL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OFL-1.1.html",
+      "referenceNumber": 325,
+      "name": "SIL Open Font License 1.1",
+      "licenseId": "OFL-1.1",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OGDL-Taiwan-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OGDL-Taiwan-1.0.html",
+      "referenceNumber": 326,
+      "name": "Taiwan Open Government Data License, version 1.0",
+      "licenseId": "OGDL-Taiwan-1.0",
+      "seeAlso": [
+        "https://data.gov.tw/license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGC-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OGC-1.0.html",
+      "referenceNumber": 327,
+      "name": "OGC Software License, Version 1.0",
+      "licenseId": "OGC-1.0",
+      "seeAlso": [
+        "https://www.ogc.org/ogc/software/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-UK-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OGL-UK-1.0.html",
+      "referenceNumber": 328,
+      "name": "Open Government Licence v1.0",
+      "licenseId": "OGL-UK-1.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/1/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-UK-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OGL-UK-2.0.html",
+      "referenceNumber": 329,
+      "name": "Open Government Licence v2.0",
+      "licenseId": "OGL-UK-2.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-UK-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OGL-UK-3.0.html",
+      "referenceNumber": 330,
+      "name": "Open Government Licence v3.0",
+      "licenseId": "OGL-UK-3.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGTSL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OGTSL.html",
+      "referenceNumber": 331,
+      "name": "Open Group Test Suite License",
+      "licenseId": "OGTSL",
+      "seeAlso": [
+        "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
+        "https://opensource.org/licenses/OGTSL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OLDAP-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-1.1.html",
+      "referenceNumber": 332,
+      "name": "Open LDAP Public License v1.1",
+      "licenseId": "OLDAP-1.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d806557a5ad59804ef3a44d5abfbe91d706b0791f"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-1.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-1.2.html",
+      "referenceNumber": 333,
+      "name": "Open LDAP Public License v1.2",
+      "licenseId": "OLDAP-1.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d42b0383c50c299977b5893ee695cf4e486fb0dc7"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-1.3.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-1.3.html",
+      "referenceNumber": 334,
+      "name": "Open LDAP Public License v1.3",
+      "licenseId": "OLDAP-1.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003de5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-Canada-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OGL-Canada-2.0.html",
+      "referenceNumber": 335,
+      "name": "Open Government Licence - Canada",
+      "licenseId": "OGL-Canada-2.0",
+      "seeAlso": [
+        "https://open.canada.ca/en/open-government-licence-canada"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.0.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.0.1.html",
+      "referenceNumber": 336,
+      "name": "Open LDAP Public License v2.0.1",
+      "licenseId": "OLDAP-2.0.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db6d68acd14e51ca3aab4428bf26522aa74873f0e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.0.html",
+      "referenceNumber": 337,
+      "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
+      "licenseId": "OLDAP-2.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.1.html",
+      "referenceNumber": 338,
+      "name": "Open LDAP Public License v2.1",
+      "licenseId": "OLDAP-2.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db0d176738e96a0d3b9f85cb51e140a86f21be715"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.2.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.2.1.html",
+      "referenceNumber": 339,
+      "name": "Open LDAP Public License v2.2.1",
+      "licenseId": "OLDAP-2.2.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d4bc786f34b50aa301be6f5600f58a980070f481e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.2.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.2.2.html",
+      "referenceNumber": 340,
+      "name": "Open LDAP Public License 2.2.2",
+      "licenseId": "OLDAP-2.2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003ddf2cc1e21eb7c160695f5b7cffd6296c151ba188"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.2.html",
+      "referenceNumber": 341,
+      "name": "Open LDAP Public License v2.2",
+      "licenseId": "OLDAP-2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d470b0c18ec67621c85881b2733057fecf4a1acc3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ODbL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ODbL-1.0.html",
+      "referenceNumber": 342,
+      "name": "Open Data Commons Open Database License v1.0",
+      "licenseId": "ODbL-1.0",
+      "seeAlso": [
+        "http://www.opendatacommons.org/licenses/odbl/1.0/",
+        "https://opendatacommons.org/licenses/odbl/1-0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.4.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.4.html",
+      "referenceNumber": 343,
+      "name": "Open LDAP Public License v2.4",
+      "licenseId": "OLDAP-2.4",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcd1284c4a91a8a380d904eee68d1583f989ed386"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-1.4.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-1.4.html",
+      "referenceNumber": 344,
+      "name": "Open LDAP Public License v1.4",
+      "licenseId": "OLDAP-1.4",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dc9f95c2f3f2ffb5e0ae55fe7388af75547660941"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.3.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.3.html",
+      "referenceNumber": 345,
+      "name": "Open LDAP Public License v2.3",
+      "licenseId": "OLDAP-2.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dd32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.7.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.7.html",
+      "referenceNumber": 346,
+      "name": "Open LDAP Public License v2.7",
+      "licenseId": "OLDAP-2.7",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d47c2415c1df81556eeb39be6cad458ef87c534a2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.8.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.8.html",
+      "referenceNumber": 347,
+      "name": "Open LDAP Public License v2.8",
+      "licenseId": "OLDAP-2.8",
+      "seeAlso": [
+        "http://www.openldap.org/software/release/license.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OML.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OML.html",
+      "referenceNumber": 348,
+      "name": "Open Market License",
+      "licenseId": "OML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OpenSSL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OpenSSL.html",
+      "referenceNumber": 349,
+      "name": "OpenSSL License",
+      "licenseId": "OpenSSL",
+      "seeAlso": [
+        "http://www.openssl.org/source/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.6.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.6.html",
+      "referenceNumber": 350,
+      "name": "Open LDAP Public License v2.6",
+      "licenseId": "OLDAP-2.6",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d1cae062821881f41b73012ba816434897abf4205"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OPL-1.0.html",
+      "referenceNumber": 351,
+      "name": "Open Public License v1.0",
+      "licenseId": "OPL-1.0",
+      "seeAlso": [
+        "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
+        "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OSL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OSL-1.0.html",
+      "referenceNumber": 352,
+      "name": "Open Software License 1.0",
+      "licenseId": "OSL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/OSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OSL-1.1.html",
+      "referenceNumber": 353,
+      "name": "Open Software License 1.1",
+      "licenseId": "OSL-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/OSL1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OSL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OSL-2.0.html",
+      "referenceNumber": 354,
+      "name": "Open Software License 2.0",
+      "licenseId": "OSL-2.0",
+      "seeAlso": [
+        "http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSET-PL-2.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OSET-PL-2.1.html",
+      "referenceNumber": 355,
+      "name": "OSET Public License version 2.1",
+      "licenseId": "OSET-PL-2.1",
+      "seeAlso": [
+        "http://www.osetfoundation.org/public-license",
+        "https://opensource.org/licenses/OPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-2.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OSL-2.1.html",
+      "referenceNumber": 356,
+      "name": "Open Software License 2.1",
+      "licenseId": "OSL-2.1",
+      "seeAlso": [
+        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
+        "https://opensource.org/licenses/OSL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Parity-6.0.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Parity-6.0.0.html",
+      "referenceNumber": 357,
+      "name": "The Parity Public License 6.0.0",
+      "licenseId": "Parity-6.0.0",
+      "seeAlso": [
+        "https://paritylicense.com/versions/6.0.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Parity-7.0.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Parity-7.0.0.html",
+      "referenceNumber": 358,
+      "name": "The Parity Public License 7.0.0",
+      "licenseId": "Parity-7.0.0",
+      "seeAlso": [
+        "https://paritylicense.com/versions/7.0.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PDDL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./PDDL-1.0.html",
+      "referenceNumber": 359,
+      "name": "Open Data Commons Public Domain Dedication \u0026 License 1.0",
+      "licenseId": "PDDL-1.0",
+      "seeAlso": [
+        "http://opendatacommons.org/licenses/pddl/1.0/",
+        "https://opendatacommons.org/licenses/pddl/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PHP-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./PHP-3.0.html",
+      "referenceNumber": 360,
+      "name": "PHP License v3.0",
+      "licenseId": "PHP-3.0",
+      "seeAlso": [
+        "http://www.php.net/license/3_0.txt",
+        "https://opensource.org/licenses/PHP-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OSL-3.0.html",
+      "referenceNumber": 361,
+      "name": "Open Software License 3.0",
+      "licenseId": "OSL-3.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
+        "https://opensource.org/licenses/OSL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Plexus.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Plexus.html",
+      "referenceNumber": 362,
+      "name": "Plexus Classworlds License",
+      "licenseId": "Plexus",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MS-PL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MS-PL.html",
+      "referenceNumber": 363,
+      "name": "Microsoft Public License",
+      "licenseId": "MS-PL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "https://opensource.org/licenses/MS-PL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./PolyForm-Small-Business-1.0.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./PolyForm-Small-Business-1.0.0.html",
+      "referenceNumber": 364,
+      "name": "PolyForm Small Business License 1.0.0",
+      "licenseId": "PolyForm-Small-Business-1.0.0",
+      "seeAlso": [
+        "https://polyformproject.org/licenses/small-business/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PolyForm-Noncommercial-1.0.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./PolyForm-Noncommercial-1.0.0.html",
+      "referenceNumber": 365,
+      "name": "PolyForm Noncommercial License 1.0.0",
+      "licenseId": "PolyForm-Noncommercial-1.0.0",
+      "seeAlso": [
+        "https://polyformproject.org/licenses/noncommercial/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PSF-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./PSF-2.0.html",
+      "referenceNumber": 366,
+      "name": "Python Software Foundation License 2.0",
+      "licenseId": "PSF-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Python-2.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./psfrag.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./psfrag.html",
+      "referenceNumber": 367,
+      "name": "psfrag License",
+      "licenseId": "psfrag",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psfrag"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PostgreSQL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./PostgreSQL.html",
+      "referenceNumber": 368,
+      "name": "PostgreSQL License",
+      "licenseId": "PostgreSQL",
+      "seeAlso": [
+        "http://www.postgresql.org/about/licence",
+        "https://opensource.org/licenses/PostgreSQL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./psutils.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./psutils.html",
+      "referenceNumber": 369,
+      "name": "psutils License",
+      "licenseId": "psutils",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psutils"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Qhull.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Qhull.html",
+      "referenceNumber": 370,
+      "name": "Qhull License",
+      "licenseId": "Qhull",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Qhull"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./QPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./QPL-1.0.html",
+      "referenceNumber": 371,
+      "name": "Q Public License 1.0",
+      "licenseId": "QPL-1.0",
+      "seeAlso": [
+        "http://doc.qt.nokia.com/3.3/license.html",
+        "https://opensource.org/licenses/QPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Rdisc.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Rdisc.html",
+      "referenceNumber": 372,
+      "name": "Rdisc License",
+      "licenseId": "Rdisc",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Python-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Python-2.0.html",
+      "referenceNumber": 373,
+      "name": "Python License 2.0",
+      "licenseId": "Python-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Python-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RPL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./RPL-1.1.html",
+      "referenceNumber": 374,
+      "name": "Reciprocal Public License 1.1",
+      "licenseId": "RPL-1.1",
+      "seeAlso": [
+        "https://opensource.org/licenses/RPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RPL-1.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./RPL-1.5.html",
+      "referenceNumber": 375,
+      "name": "Reciprocal Public License 1.5",
+      "licenseId": "RPL-1.5",
+      "seeAlso": [
+        "https://opensource.org/licenses/RPL-1.5"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RHeCos-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./RHeCos-1.1.html",
+      "referenceNumber": 376,
+      "name": "Red Hat eCos Public License v1.1",
+      "licenseId": "RHeCos-1.1",
+      "seeAlso": [
+        "http://ecos.sourceware.org/old-license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./RSA-MD.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./RSA-MD.html",
+      "referenceNumber": 377,
+      "name": "RSA Message-Digest License",
+      "licenseId": "RSA-MD",
+      "seeAlso": [
+        "http://www.faqs.org/rfcs/rfc1321.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./RSCPL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./RSCPL.html",
+      "referenceNumber": 378,
+      "name": "Ricoh Source Code Public License",
+      "licenseId": "RSCPL",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
+        "https://opensource.org/licenses/RSCPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Ruby.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Ruby.html",
+      "referenceNumber": 379,
+      "name": "Ruby License",
+      "licenseId": "Ruby",
+      "seeAlso": [
+        "http://www.ruby-lang.org/en/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SAX-PD.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SAX-PD.html",
+      "referenceNumber": 380,
+      "name": "Sax Public Domain Notice",
+      "licenseId": "SAX-PD",
+      "seeAlso": [
+        "http://www.saxproject.org/copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Saxpath.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Saxpath.html",
+      "referenceNumber": 381,
+      "name": "Saxpath License",
+      "licenseId": "Saxpath",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SCEA.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SCEA.html",
+      "referenceNumber": 382,
+      "name": "SCEA Shared Source License",
+      "licenseId": "SCEA",
+      "seeAlso": [
+        "http://research.scea.com/scea_shared_source_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Sendmail-8.23.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Sendmail-8.23.html",
+      "referenceNumber": 383,
+      "name": "Sendmail License 8.23",
+      "licenseId": "Sendmail-8.23",
+      "seeAlso": [
+        "https://www.proofpoint.com/sites/default/files/sendmail-license.pdf",
+        "https://web.archive.org/web/20181003101040/https://www.proofpoint.com/sites/default/files/sendmail-license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Sendmail.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Sendmail.html",
+      "referenceNumber": 384,
+      "name": "Sendmail License",
+      "licenseId": "Sendmail",
+      "seeAlso": [
+        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
+        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SGI-B-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SGI-B-1.0.html",
+      "referenceNumber": 385,
+      "name": "SGI Free Software License B v1.0",
+      "licenseId": "SGI-B-1.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SGI-B-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SGI-B-1.1.html",
+      "referenceNumber": 386,
+      "name": "SGI Free Software License B v1.1",
+      "licenseId": "SGI-B-1.1",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SGI-B-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SGI-B-2.0.html",
+      "referenceNumber": 387,
+      "name": "SGI Free Software License B v2.0",
+      "licenseId": "SGI-B-2.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SHL-0.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SHL-0.5.html",
+      "referenceNumber": 388,
+      "name": "Solderpad Hardware License v0.5",
+      "licenseId": "SHL-0.5",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-0.5/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SHL-0.51.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SHL-0.51.html",
+      "referenceNumber": 389,
+      "name": "Solderpad Hardware License, Version 0.51",
+      "licenseId": "SHL-0.51",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-0.51/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SimPL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SimPL-2.0.html",
+      "referenceNumber": 390,
+      "name": "Simple Public License 2.0",
+      "licenseId": "SimPL-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/SimPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SISSL-1.2.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SISSL-1.2.html",
+      "referenceNumber": 391,
+      "name": "Sun Industry Standards Source License v1.2",
+      "licenseId": "SISSL-1.2",
+      "seeAlso": [
+        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SISSL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SISSL.html",
+      "referenceNumber": 392,
+      "name": "Sun Industry Standards Source License v1.1",
+      "licenseId": "SISSL",
+      "seeAlso": [
+        "http://www.openoffice.org/licenses/sissl_license.html",
+        "https://opensource.org/licenses/SISSL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Sleepycat.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Sleepycat.html",
+      "referenceNumber": 393,
+      "name": "Sleepycat License",
+      "licenseId": "Sleepycat",
+      "seeAlso": [
+        "https://opensource.org/licenses/Sleepycat"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SMLNJ.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SMLNJ.html",
+      "referenceNumber": 394,
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "SMLNJ",
+      "seeAlso": [
+        "https://www.smlnj.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SMPPL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SMPPL.html",
+      "referenceNumber": 395,
+      "name": "Secure Messaging Protocol Public License",
+      "licenseId": "SMPPL",
+      "seeAlso": [
+        "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SNIA.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SNIA.html",
+      "referenceNumber": 396,
+      "name": "SNIA Public License 1.1",
+      "licenseId": "SNIA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Spencer-86.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Spencer-86.html",
+      "referenceNumber": 397,
+      "name": "Spencer License 86",
+      "licenseId": "Spencer-86",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Spencer-94.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Spencer-94.html",
+      "referenceNumber": 398,
+      "name": "Spencer License 94",
+      "licenseId": "Spencer-94",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Spencer-99.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Spencer-99.html",
+      "referenceNumber": 399,
+      "name": "Spencer License 99",
+      "licenseId": "Spencer-99",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SPL-1.0.html",
+      "referenceNumber": 400,
+      "name": "Sun Public License v1.0",
+      "licenseId": "SPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/SPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SSH-OpenSSH.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SSH-OpenSSH.html",
+      "referenceNumber": 401,
+      "name": "SSH OpenSSH license",
+      "licenseId": "SSH-OpenSSH",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/LICENCE#L10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PHP-3.01.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./PHP-3.01.html",
+      "referenceNumber": 402,
+      "name": "PHP License v3.01",
+      "licenseId": "PHP-3.01",
+      "seeAlso": [
+        "http://www.php.net/license/3_01.txt"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SSH-short.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SSH-short.html",
+      "referenceNumber": 403,
+      "name": "SSH short notice",
+      "licenseId": "SSH-short",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/pathnames.h",
+        "http://web.mit.edu/kolya/.f/root/athena.mit.edu/sipb.mit.edu/project/openssh/OldFiles/src/openssh-2.9.9p2/ssh-add.1",
+        "https://joinup.ec.europa.eu/svn/lesoll/trunk/italc/lib/src/dsa_key.cpp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./MIT-0.html",
+      "referenceNumber": 404,
+      "name": "MIT No Attribution",
+      "licenseId": "MIT-0",
+      "seeAlso": [
+        "https://github.com/aws/mit-0",
+        "https://romanrm.net/mit-zero",
+        "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RPSL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./RPSL-1.0.html",
+      "referenceNumber": 405,
+      "name": "RealNetworks Public Source License v1.0",
+      "licenseId": "RPSL-1.0",
+      "seeAlso": [
+        "https://helixcommunity.org/content/rpsl",
+        "https://opensource.org/licenses/RPSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SWL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SWL.html",
+      "referenceNumber": 406,
+      "name": "Scheme Widget Library (SWL) Software License Agreement",
+      "licenseId": "SWL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SWL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SugarCRM-1.1.3.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SugarCRM-1.1.3.html",
+      "referenceNumber": 407,
+      "name": "SugarCRM Public License v1.1.3",
+      "licenseId": "SugarCRM-1.1.3",
+      "seeAlso": [
+        "http://www.sugarcrm.com/crm/SPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TCL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./TCL.html",
+      "referenceNumber": 408,
+      "name": "TCL/TK License",
+      "licenseId": "TCL",
+      "seeAlso": [
+        "http://www.tcl.tk/software/tcltk/license.html",
+        "https://fedoraproject.org/wiki/Licensing/TCL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TCP-wrappers.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./TCP-wrappers.html",
+      "referenceNumber": 409,
+      "name": "TCP Wrappers License",
+      "licenseId": "TCP-wrappers",
+      "seeAlso": [
+        "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SSPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SSPL-1.0.html",
+      "referenceNumber": 410,
+      "name": "Server Side Public License, v 1",
+      "licenseId": "SSPL-1.0",
+      "seeAlso": [
+        "https://www.mongodb.com/licensing/server-side-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TMate.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./TMate.html",
+      "referenceNumber": 411,
+      "name": "TMate Open Source License",
+      "licenseId": "TMate",
+      "seeAlso": [
+        "http://svnkit.com/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TOSL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./TOSL.html",
+      "referenceNumber": 412,
+      "name": "Trusster Open Source License",
+      "licenseId": "TOSL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TOSL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TORQUE-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./TORQUE-1.1.html",
+      "referenceNumber": 413,
+      "name": "TORQUE v2.5+ Software License v1.1",
+      "licenseId": "TORQUE-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TAPR-OHL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./TAPR-OHL-1.0.html",
+      "referenceNumber": 414,
+      "name": "TAPR Open Hardware License v1.0",
+      "licenseId": "TAPR-OHL-1.0",
+      "seeAlso": [
+        "https://www.tapr.org/OHL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./UCL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./UCL-1.0.html",
+      "referenceNumber": 415,
+      "name": "Upstream Compatibility License v1.0",
+      "licenseId": "UCL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/UCL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Unicode-DFS-2015.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Unicode-DFS-2015.html",
+      "referenceNumber": 416,
+      "name": "Unicode License Agreement - Data Files and Software (2015)",
+      "licenseId": "Unicode-DFS-2015",
+      "seeAlso": [
+        "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Unicode-DFS-2016.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Unicode-DFS-2016.html",
+      "referenceNumber": 417,
+      "name": "Unicode License Agreement - Data Files and Software (2016)",
+      "licenseId": "Unicode-DFS-2016",
+      "seeAlso": [
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Unicode-TOU.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Unicode-TOU.html",
+      "referenceNumber": 418,
+      "name": "Unicode Terms of Use",
+      "licenseId": "Unicode-TOU",
+      "seeAlso": [
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TU-Berlin-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./TU-Berlin-1.0.html",
+      "referenceNumber": 419,
+      "name": "Technische Universitaet Berlin License 1.0",
+      "licenseId": "TU-Berlin-1.0",
+      "seeAlso": [
+        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./UPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./UPL-1.0.html",
+      "referenceNumber": 420,
+      "name": "Universal Permissive License v1.0",
+      "licenseId": "UPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/UPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Unlicense.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Unlicense.html",
+      "referenceNumber": 421,
+      "name": "The Unlicense",
+      "licenseId": "Unlicense",
+      "seeAlso": [
+        "https://unlicense.org/"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./VOSTROM.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./VOSTROM.html",
+      "referenceNumber": 422,
+      "name": "VOSTROM Public License for Open Source",
+      "licenseId": "VOSTROM",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/VOSTROM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Vim.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Vim.html",
+      "referenceNumber": 423,
+      "name": "Vim License",
+      "licenseId": "Vim",
+      "seeAlso": [
+        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./VSL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./VSL-1.0.html",
+      "referenceNumber": 424,
+      "name": "Vovida Software License v1.0",
+      "licenseId": "VSL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/VSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./W3C-20150513.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./W3C-20150513.html",
+      "referenceNumber": 425,
+      "name": "W3C Software Notice and Document License (2015-05-13)",
+      "licenseId": "W3C-20150513",
+      "seeAlso": [
+        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./W3C.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./W3C.html",
+      "referenceNumber": 426,
+      "name": "W3C Software Notice and License (2002-12-31)",
+      "licenseId": "W3C",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
+        "https://opensource.org/licenses/W3C"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./W3C-19980720.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./W3C-19980720.html",
+      "referenceNumber": 427,
+      "name": "W3C Software Notice and License (1998-07-20)",
+      "licenseId": "W3C-19980720",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Wsuipa.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Wsuipa.html",
+      "referenceNumber": 428,
+      "name": "Wsuipa License",
+      "licenseId": "Wsuipa",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Wsuipa"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Watcom-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Watcom-1.0.html",
+      "referenceNumber": 429,
+      "name": "Sybase Open Watcom Public License 1.0",
+      "licenseId": "Watcom-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Watcom-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./WTFPL.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./WTFPL.html",
+      "referenceNumber": 430,
+      "name": "Do What The F*ck You Want To Public License",
+      "licenseId": "WTFPL",
+      "seeAlso": [
+        "http://www.wtfpl.net/about/",
+        "http://sam.zoy.org/wtfpl/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./X11.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./X11.html",
+      "referenceNumber": 431,
+      "name": "X11 License",
+      "licenseId": "X11",
+      "seeAlso": [
+        "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Xerox.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Xerox.html",
+      "referenceNumber": 432,
+      "name": "Xerox License",
+      "licenseId": "Xerox",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xerox"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./XFree86-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./XFree86-1.1.html",
+      "referenceNumber": 433,
+      "name": "XFree86 License 1.1",
+      "licenseId": "XFree86-1.1",
+      "seeAlso": [
+        "http://www.xfree86.org/current/LICENSE4.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./xinetd.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./xinetd.html",
+      "referenceNumber": 434,
+      "name": "xinetd License",
+      "licenseId": "xinetd",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Xnet.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Xnet.html",
+      "referenceNumber": 435,
+      "name": "X.Net License",
+      "licenseId": "Xnet",
+      "seeAlso": [
+        "https://opensource.org/licenses/Xnet"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./xpp.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./xpp.html",
+      "referenceNumber": 436,
+      "name": "XPP License",
+      "licenseId": "xpp",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/xpp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./XSkat.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./XSkat.html",
+      "referenceNumber": 437,
+      "name": "XSkat License",
+      "licenseId": "XSkat",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./YPL-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./YPL-1.0.html",
+      "referenceNumber": 438,
+      "name": "Yahoo! Public License v1.0",
+      "licenseId": "YPL-1.0",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./YPL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./YPL-1.1.html",
+      "referenceNumber": 439,
+      "name": "Yahoo! Public License v1.1",
+      "licenseId": "YPL-1.1",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zed.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Zed.html",
+      "referenceNumber": 440,
+      "name": "Zed License",
+      "licenseId": "Zed",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Zed"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zend-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Zend-2.0.html",
+      "referenceNumber": 441,
+      "name": "Zend License v2.0",
+      "licenseId": "Zend-2.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TU-Berlin-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./TU-Berlin-2.0.html",
+      "referenceNumber": 442,
+      "name": "Technische Universitaet Berlin License 2.0",
+      "licenseId": "TU-Berlin-2.0",
+      "seeAlso": [
+        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zimbra-1.4.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Zimbra-1.4.html",
+      "referenceNumber": 443,
+      "name": "Zimbra Public License v1.4",
+      "licenseId": "Zimbra-1.4",
+      "seeAlso": [
+        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./zlib-acknowledgement.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./zlib-acknowledgement.html",
+      "referenceNumber": 444,
+      "name": "zlib/libpng License with Acknowledgement",
+      "licenseId": "zlib-acknowledgement",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zlib.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Zlib.html",
+      "referenceNumber": 445,
+      "name": "zlib License",
+      "licenseId": "Zlib",
+      "seeAlso": [
+        "http://www.zlib.net/zlib_license.html",
+        "https://opensource.org/licenses/Zlib"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ZPL-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ZPL-1.1.html",
+      "referenceNumber": 446,
+      "name": "Zope Public License 1.1",
+      "licenseId": "ZPL-1.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ZPL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ZPL-2.0.html",
+      "referenceNumber": 447,
+      "name": "Zope Public License 2.0",
+      "licenseId": "ZPL-2.0",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-2.0",
+        "https://opensource.org/licenses/ZPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ZPL-2.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./ZPL-2.1.html",
+      "referenceNumber": 448,
+      "name": "Zope Public License 2.1",
+      "licenseId": "ZPL-2.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/ZPL/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./wxWindows.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./wxWindows.html",
+      "referenceNumber": 449,
+      "name": "wxWindows Library License",
+      "licenseId": "wxWindows",
+      "seeAlso": [
+        "https://opensource.org/licenses/WXwindows"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zimbra-1.3.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Zimbra-1.3.html",
+      "referenceNumber": 450,
+      "name": "Zimbra Public License v1.3",
+      "licenseId": "Zimbra-1.3",
+      "seeAlso": [
+        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./gSOAP-1.3b.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./gSOAP-1.3b.html",
+      "referenceNumber": 451,
+      "name": "gSOAP Public License v1.3b",
+      "licenseId": "gSOAP-1.3b",
+      "seeAlso": [
+        "http://www.cs.fsu.edu/~engelen/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Interbase-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Interbase-1.0.html",
+      "referenceNumber": 452,
+      "name": "Interbase Public License v1.0",
+      "licenseId": "Interbase-1.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LGPL-2.1.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./LGPL-2.1.html",
+      "referenceNumber": 453,
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./LGPL-3.0.html",
+      "referenceNumber": 454,
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NPOSL-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./NPOSL-3.0.html",
+      "referenceNumber": 455,
+      "name": "Non-Profit Open Software License 3.0",
+      "licenseId": "NPOSL-3.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/NOSL3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OLDAP-2.5.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OLDAP-2.5.html",
+      "referenceNumber": 456,
+      "name": "Open LDAP Public License v2.5",
+      "licenseId": "OLDAP-2.5",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d6852b9d90022e8593c98205413380536b1b5a7cf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./StandardML-NJ.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./StandardML-NJ.html",
+      "referenceNumber": 457,
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "StandardML-NJ",
+      "seeAlso": [
+        "http://www.smlnj.org//license.html"
+      ],
+      "isOsiApproved": false
+    }
+  ],
+  "releaseDate": "2021-03-07"
+}


### PR DESCRIPTION
Add component license information (as stated in the yocto recipe) into the generated SBOM.

If the recipe license contains "&" or "|", we assume this is a expression, adding it to licenses.expression.
If the recipe license matches a singular known SPDX license identifier, the license ID is added to licenses[0].license.id. Otherwise, it is added as licenses[0].license.name

Fixes https://github.com/iris-GmbH/meta-cyclonedx/issues/32