### PR TITLE
Fix VEX false positives from CVE patch file suffixes

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -386,6 +386,23 @@ def generate_packages_list(products_names, version):
         packages.append(pkg)
     return packages
 
+def normalize_cve_id(cve_id):
+    """
+    Normalize CVE ID by removing patch file suffixes.
+    
+    Yocto recipes often use multiple patches for the same CVE with suffixes like:
+    - CVE-2025-52886-0001.patch
+    - CVE-2025-52886-0002.patch
+    
+    This function strips the numeric suffix to get the canonical CVE ID.
+    """
+    import re
+    # Match CVE-YYYY-NNNNN format, optionally followed by -NNNN suffix
+    match = re.match(r'(CVE-\d{4}-\d+)(?:-\d+)?', cve_id)
+    if match:
+        return match.group(1)
+    return cve_id
+
 def append_to_vex(d, cve, cves, bom_ref):
     """
     Collect CVE status information from within open embedded recipes and append to add to cve dictionary.
@@ -394,23 +411,38 @@ def append_to_vex(d, cve, cves, bom_ref):
     from datetime import datetime, timezone
     
     cve_id, abbrev_status, status, justification = cve
+    
+    # Normalize CVE ID to remove patch file suffixes (e.g., CVE-2025-52886-0001 -> CVE-2025-52886)
+    normalized_cve_id = normalize_cve_id(cve_id)
 
     # Currently, only "Patched" and "Ignored" status are relevant to us.
     # See https://docs.yoctoproject.org/singleindex.html#term-CVE_CHECK_STATUSMAP for possible statuses.
     if abbrev_status == "Patched":
-        bb.debug(2, f"Found patch for {cve_id} in {d.getVar('BPN')}")
+        bb.debug(2, f"Found patch for {normalized_cve_id} in {d.getVar('BPN')}")
         vex_state = "resolved"
     elif abbrev_status == "Ignored":
-        bb.debug(2, f"Found ignore statement for {cve_id} in {d.getVar('BPN')}")
+        bb.debug(2, f"Found ignore statement for {normalized_cve_id} in {d.getVar('BPN')}")
         vex_state = "not_affected"
     else:
-        bb.debug(2, f"Found unknown or irrelevant CVE status {abbrev_status} for {cve_id} in {d.getVar('BPN')}. Skipping...")
+        bb.debug(2, f"Found unknown or irrelevant CVE status {abbrev_status} for {normalized_cve_id} in {d.getVar('BPN')}. Skipping...")
         return
+
+    # Check if this CVE already exists in the list (avoid duplicates from multiple patches)
+    for existing_cve in cves:
+        if existing_cve["id"] == normalized_cve_id:
+            # CVE already recorded, just update the detail to mention this patch too
+            if cve_id != normalized_cve_id:  # Only if there was a suffix
+                existing_cve["analysis"]["detail"] += f"Additional patch: {cve_id}\n"
+            bb.debug(2, f"CVE {normalized_cve_id} already recorded, updated details")
+            return
 
     detail_string = ""
     detail_string += f"STATE: {status}\n"
     if justification:
         detail_string += f"JUSTIFICATION: {justification}\n"
+    # Mention original patch filename if it had a suffix
+    if cve_id != normalized_cve_id:
+        detail_string += f"Patch file: {cve_id}\n"
 
     # Build analysis object
     analysis = {
@@ -429,10 +461,10 @@ def append_to_vex(d, cve, cves, bom_ref):
         analysis["lastUpdated"] = timestamp
 
     cves.append({
-        "id": cve_id,
+        "id": normalized_cve_id,
         # vex documents require a valid source, see https://github.com/DependencyTrack/dependency-track/issues/2977
         # this should always be NVD for yocto CVEs.
-        "source": {"name": "NVD", "url": f"https://nvd.nist.gov/vuln/detail/{cve_id}"},
+        "source": {"name": "NVD", "url": f"https://nvd.nist.gov/vuln/detail/{normalized_cve_id}"},
         "analysis": analysis,
         "affects": [{"ref": f"urn:cdx:{d.getVar('CYCLONEDX_SBOM_SERIAL_PLACEHOLDER')}/1#{bom_ref}"}]
     })


### PR DESCRIPTION
## Summary

Fixes issue #43 - VEX documents were containing invalid CVE identifiers when recipes use multiple patches for the same CVE.

## Problem

When Yocto recipes apply multiple patches for the same CVE with numeric suffixes (e.g., `CVE-2025-52886-0001.patch`, `CVE-2025-52886-0002.patch`), the `get_patched_cves()` function from Yocto's `oe.cve_check` module returns the full patch filename prefix including the suffix as the CVE ID.

This resulted in VEX documents containing invalid entries like:
```json
{
  "id": "CVE-2025-52886-0001",
  "source": {
    "name": "NVD",
    "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52886-0001"
  }
}
```

These invalid CVE IDs cannot be matched by vulnerability scanning tools like Dependency Track, causing false positives where patched CVEs still appear as vulnerable.

## Solution

Added CVE ID normalization that:

1. **Strips numeric suffixes** from CVE IDs using regex pattern `(CVE-\d{4}-\d+)(?:-\d+)?`
   - Example: `CVE-2025-52886-0001` → `CVE-2025-52886`

2. **Deduplicates VEX entries** when multiple patches exist for the same CVE
   - First patch creates the VEX entry with canonical CVE ID
   - Additional patches append to the detail field

3. **Preserves patch information** in the analysis detail field
   - Original patch filenames are documented for traceability

## Changes

- Added `normalize_cve_id()` helper function
- Updated `append_to_vex()` to normalize CVE IDs before creating VEX entries
- Added deduplication check to prevent multiple entries for the same CVE
- Enhanced detail field to include patch filename information

## Example Output

**Before** (invalid - multiple entries):
```json
{
  "id": "CVE-2025-52886-0001",
  "source": {"url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52886-0001"\}
},
{
  "id": "CVE-2025-52886-0002",
  "source": {"url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52886-0002"\}
}
```

**After** (valid - single entry):
```json
{
  "id": "CVE-2025-52886",
  "source": {"url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52886"\},
  "analysis": {
    "detail": "STATE: Patched\nPatch file: CVE-2025-52886-0001\nAdditional patch: CVE-2025-52886-0002\n"
  }
}
```

## Impact

- ✅ VEX documents now contain valid CVE identifiers
- ✅ Vulnerability scanners can properly match patched CVEs
- ✅ No more false positives from multi-patch CVEs
- ✅ Backward compatible - canonical CVE IDs remain unchanged
- ✅ Traceability maintained via detail field

## Testing

Tested with the poppler recipe from meta-openembedded which uses multiple patches for several CVEs including CVE-2024-6239 and CVE-2025-52886.

## Related Issues

Closes #43
