### PR TITLE
Delay inserting sbom_serial_number in vex data (#48)

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -191,6 +191,13 @@ def write_json(path, content):
         json.dumps(content, indent=2)
     )
 
+def write_json_replace(path, content, old, new):
+    import json
+    from pathlib import Path
+    Path(path).write_text(
+        json.dumps(content, indent=2).replace(old, new)
+    )
+
 def convert_to_spdx_license(d, spdx_license_ids):
     """
     Converts an OE license (expression) (see: https://docs.yoctoproject.org/singleindex.html#term-LICENSE)
@@ -589,8 +596,6 @@ python do_deploy_cyclonedx() {
                         pn_pkg["scope"] = "optional"
                 sbom["components"].append(pn_pkg)
         for pn_cve in pn_list["cves"]:
-            pn_cve["affects"][0]["ref"] = pn_cve["affects"][0]["ref"].replace(
-                d.getVar('CYCLONEDX_SBOM_SERIAL_PLACEHOLDER'), sbom_serial_number)
             vex["vulnerabilities"].append(pn_cve)
 
         # Add dependencies
@@ -624,7 +629,7 @@ python do_deploy_cyclonedx() {
     d.setVar("PN", save_pn)
 
     write_json(d.getVar("CYCLONEDX_EXPORT_SBOM"), sbom)
-    write_json(d.getVar("CYCLONEDX_EXPORT_VEX"), vex)
+    write_json_replace(d.getVar("CYCLONEDX_EXPORT_VEX"), vex, d.getVar('CYCLONEDX_SBOM_SERIAL_PLACEHOLDER'), sbom_serial_number)
 }
 do_deploy_cyclonedx[cleandirs] = "${CYCLONEDX_EXPORT_DIR}"
 


### PR DESCRIPTION
The sbom_serial_number was replaced while processing the first image in a multi-image build (eg a main rootfs and an initramfs). That caused the vulnerabilities in the vex file for the main rootfs to sometimes point to components in the sbom for the initramfs.

Here, we delay replacing the sbom_serial_number until we're actually writing out the vex-file.

An alternative approach tested was to use:
```
        for pn_cve in pn_list["cves"]:
            cve = pn_cve.copy()
            cve["affects"][0]["ref"] = cve["affects"][0]["ref"].replace(
                d.getVar('CYCLONEDX_SBOM_SERIAL_PLACEHOLDER'), sbom_serial_number)
            vex["vulnerabilities"].append(cve)
```
instead, i.e., to make a copy of the actual cve before modifying it. This allows us to make no other changes, OTOH, we're duplicating the data for all CVEs...