### PR TITLE
fix: Defer SBOM serial number replacement to prevent VEX mismatches i…

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -589,8 +589,8 @@ python do_deploy_cyclonedx() {
                         pn_pkg["scope"] = "optional"
                 sbom["components"].append(pn_pkg)
         for pn_cve in pn_list["cves"]:
-            pn_cve["affects"][0]["ref"] = pn_cve["affects"][0]["ref"].replace(
-                d.getVar('CYCLONEDX_SBOM_SERIAL_PLACEHOLDER'), sbom_serial_number)
+            # Don't replace serial number yet - it will be done after all CVEs are collected
+            # This fixes multi-output builds where shared components would get the wrong serial
             vex["vulnerabilities"].append(pn_cve)
 
         # Add dependencies
@@ -622,6 +622,15 @@ python do_deploy_cyclonedx() {
             write_json(pn_list_filepath, pn_list)
 
     d.setVar("PN", save_pn)
+
+    # Replace SBOM serial placeholder in VEX vulnerabilities
+    # This must be done after all vulnerabilities are collected to ensure each image
+    # gets its own SBOM serial number in multi-output builds (e.g., rootfs + initramfs)
+    for vuln in vex["vulnerabilities"]:
+        for affect in vuln.get("affects", []):
+            if "ref" in affect:
+                affect["ref"] = affect["ref"].replace(
+                    d.getVar('CYCLONEDX_SBOM_SERIAL_PLACEHOLDER'), sbom_serial_number)
 
     write_json(d.getVar("CYCLONEDX_EXPORT_SBOM"), sbom)
     write_json(d.getVar("CYCLONEDX_EXPORT_VEX"), vex)


### PR DESCRIPTION
## Summary

Fixes #48 - Vulnerabilities are now correctly attributed to their respective SBOMs in multi-output builds (e.g., rootfs + initramfs).

## Problem

When building multiple images in a single Yocto build (such as a main rootfs image with an automatically-generated initramfs using `dm-verity-img`), the generated VEX files contained vulnerabilities with mixed SBOM serial number references. Some vulnerabilities from shared components would incorrectly reference the SBOM serial number from a different image rather than the current image.

This occurred because:
1. Component data (including CVE information) is cached in BitBake's shared state
2. The SBOM serial number placeholder `<SBOM_SERIAL>` was being replaced during component aggregation
3. When the second image was built, it reused cached components that already had the first image's serial number

## Solution

Defer the SBOM serial number replacement until **after all vulnerabilities are collected**, just before writing the VEX file. This ensures each image gets its own correct SBOM serial number in all VEX `affects` references.

## Changes

- **Removed** early serial number replacement in the component aggregation loop (line ~592)
- **Added** serial number replacement at the end of `do_deploy_cyclonedx()`, after all vulnerabilities are collected (line ~626)
- Added explanatory comments documenting the multi-output build scenario

## Testing

This fix ensures that:
- Each image in a multi-output build gets its own unique SBOM serial number in VEX references
- Shared components cached in sstate work correctly across multiple images
- Single-image builds continue to work as before (no behavioral change)

## Backward Compatibility

✅ Fully backward compatible - no API changes, no configuration changes required. The fix only changes when the placeholder replacement occurs, not what gets replaced.