### PR TITLE
scarthgap: Fix duplicate vex entries

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -130,9 +130,14 @@ python do_cyclonedx_package_collect() {
                 ""
             )
             append_to_vex(d, cve, cves, bom_ref)
-        # append any cve status within recipe to pn_list cves
+
+        # in scarthgap the get_patched_cves function filters CVE_STATUS to only
+        # include "Patched" decoded status, however we want "Ignored" statuses as well.
         for cve_id in (d.getVarFlags("CVE_STATUS") or {}):
             decoded_status, state, justification = decode_cve_status(d, cve_id)
+            # avoid duplicates
+            if decoded_status == "Patched":
+                continue
             cve = (
                 cve_id,
                 decoded_status,


### PR DESCRIPTION
With commit https://github.com/yoctoproject/poky/commit/be9883a92bad0fe4c1e9c7302c93dea4ac680f8c OE's "get_patched_cves" function already includes CVE_STATUS entries with the decoded_status of "Patched". In later releases this behavior has been changed. Since we are also interested in "Ignored" CVEs, we therefore continue to include additional CVE_STATUS, while avoiding duplicates.

Fixes: https://github.com/iris-GmbH/meta-cyclonedx/issues/51