### PR TITLE
feat: add feature to export unpatched vulnerabilities to VEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,17 @@ CYCLONEDX_SPLIT_LICENSE_EXPRESSIONS = "1"
 CYCLONEDX_ADD_LICENSE_DETAILS = "1"  # Include license text for custom licenses
 CYCLONEDX_ADD_CITATION = "1"         # Document SBOM provenance
 CYCLONEDX_TLP_MARKING = ""           # TLP marking (CLEAR|GREEN|AMBER|AMBER_STRICT|RED)
+
+# Include unpatched vulnerabilities in VEX (default: "0").
+# If enabled, the cve-check class is inherited to query the NVD.
+# Note that querying the NVD happens at the time of running the
+# task, which currently requires rootfs generation. You may
+# want to use external tools such as DependencyTrack for regular analysis.
+CYCLONEDX_INCLUDE_UNPATCHED_VULNS = "1"
+
+# State to assign to unpatched vulnerabilities (default: "in_triage").
+# Can be empty to omit the state field.
+CYCLONEDX_UNPATCHED_VULNS_STATE = "in_triage"
 ```
 
 ## Usage

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -28,6 +28,17 @@ CYCLONEDX_ADD_COMPONENT_SCOPES ??= "1"
 # Available in CycloneDX 1.6
 CYCLONEDX_ADD_VULN_TIMESTAMPS ??= "1"
 
+# Include unpatched vulnerabilities in VEX.
+# If enabled, the cve-check class is inherited to query the NVD.
+# Note that querying the NVD happens at the time of running the
+# task, which currently requires rootfs generation. You may
+# want to use external tools for regular analysis.
+CYCLONEDX_INCLUDE_UNPATCHED_VULNS ??= "0"
+
+# State to assign to unpatched vulnerabilities.
+# Can be empty to omit the state field.
+CYCLONEDX_UNPATCHED_VULNS_STATE ??= "in_triage"
+
 CYCLONEDX_RUNTIME_PACKAGES_ONLY ??= "1"
 
 # Add component licenses (as specified within the recipe) to the SBOM
@@ -62,6 +73,10 @@ CYCLONEDX_WORK_DIR_PN_LIST = "${CYCLONEDX_WORK_DIR}/pn-list.json"
 # We need to add the sbom serial number to the list of vulnerabilites for each recipe but
 # don't know it until after we generate the sbom export header file
 CYCLONEDX_SBOM_SERIAL_PLACEHOLDER = "<SBOM_SERIAL>"
+
+# If unpatched vulnerabilities are to be included, we need to inherit the cve-check class.
+# This is because we rely on the `check_cves` function from that class to query the NVD.
+inherit_defer ${@ "cve-check" if d.getVar("CYCLONEDX_INCLUDE_UNPATCHED_VULNS") == "1" else ""}
 
 # resolve CVE_CHECK_IGNORE and CVE_STATUS_GROUPS,
 # taken from https://git.yoctoproject.org/poky/commit/meta/classes/cve-check.bbclass?id=be9883a92bad0fe4c1e9c7302c93dea4ac680f8c
@@ -146,7 +161,8 @@ python do_cyclonedx_package_collect() {
         bom_ref = pkg["bom-ref"]
 
         # append any CVEs either patched or taken from CVE_STATUS
-        for cve_id, cve_info in get_patched_cves(d).items():
+        patched_cves = get_patched_cves(d)
+        for cve_id, cve_info in patched_cves.items():
             cve = (
                 cve_id,
                 cve_info["abbrev-status"],
@@ -154,6 +170,29 @@ python do_cyclonedx_package_collect() {
                 cve_info.get("justification", "")
             )
             append_to_vex(d, cve, cves, bom_ref)
+
+        # The check_cves function is coming from the cve-check class
+        # that we conditionally inherit to query the NVD.
+        if d.getVar("CYCLONEDX_INCLUDE_UNPATCHED_VULNS") == "1" and os.path.exists(d.getVar("CVE_CHECK_DB_FILE")):
+            with bb.utils.fileslocked([d.getVar("CVE_CHECK_DB_FILE_LOCK")], shared=True):
+                bb.debug(2, f"Querying CVE database for unpatched CVEs for package {pn}")
+
+                # Turn off warnings and restore afterwards
+                cve_check_show_warnings_original = d.getVar("CVE_CHECK_SHOW_WARNINGS")
+                d.setVar("CVE_CHECK_SHOW_WARNINGS", "0")
+                cve_data, _ = check_cves(d, patched_cves)
+                d.setVar("CVE_CHECK_SHOW_WARNINGS", cve_check_show_warnings_original)
+
+                unpatched_cve_ids = [cve_id for cve_id, data in cve_data.items() if data["abbrev-status"] == "Unpatched"]
+                bb.debug(2, f"Found {len(unpatched_cve_ids)} unpatched CVEs for package {pn}")
+                for cve_id in unpatched_cve_ids:
+                    cve = (
+                        cve_id,
+                        "Unpatched",
+                        "no-fix-supplied",
+                        ""
+                    )
+                    append_to_vex(d, cve, cves, bom_ref)
 
     # append any cve status within recipe to pn_list cves
     pn_list["cves"] = cves
@@ -188,6 +227,10 @@ python do_cyclonedx_package_collect() {
 
 addtask do_cyclonedx_package_collect before do_build
 do_cyclonedx_package_collect[cleandirs] = "${CYCLONEDX_TMP_WORK_DIR}"
+
+# We cannot set nostamp on do_cyclonedx_package_collect conditionally due to YP bug #13808.
+# Instead, we conditionally include a file.
+require ${@ "include/include-unpatched.inc" if d.getVar("CYCLONEDX_INCLUDE_UNPATCHED_VULNS") == "1" else ""}
 
 # Utilizing shared state for output caching
 # see https://docs.yoctoproject.org/overview-manual/concepts.html#shared-state
@@ -579,7 +622,8 @@ def append_to_vex(d, cve, cves, bom_ref):
     # Normalize CVE ID to remove patch file suffixes (e.g., CVE-2025-52886-0001 -> CVE-2025-52886)
     normalized_cve_id = normalize_cve_id(cve_id)
 
-    # Currently, only "Patched" and "Ignored" status are relevant to us.
+    include_unpatched = d.getVar("CYCLONEDX_INCLUDE_UNPATCHED_VULNS") == "1"
+
     # See https://docs.yoctoproject.org/singleindex.html#term-CVE_CHECK_STATUSMAP for possible statuses.
     if abbrev_status == "Patched":
         bb.debug(2, f"Found patch for {normalized_cve_id} in {d.getVar('BPN')}")
@@ -587,6 +631,9 @@ def append_to_vex(d, cve, cves, bom_ref):
     elif abbrev_status == "Ignored":
         bb.debug(2, f"Found ignore statement for {normalized_cve_id} in {d.getVar('BPN')}")
         vex_state = "not_affected"
+    elif abbrev_status == "Unpatched" and include_unpatched:
+        bb.debug(2, f"Found unpatched status for {normalized_cve_id} in {d.getVar('BPN')}")
+        vex_state = d.getVar("CYCLONEDX_UNPATCHED_VULNS_STATE")
     else:
         bb.debug(2, f"Found unknown or irrelevant CVE status {abbrev_status} for {normalized_cve_id} in {d.getVar('BPN')}. Skipping...")
         return
@@ -610,9 +657,10 @@ def append_to_vex(d, cve, cves, bom_ref):
 
     # Build analysis object
     analysis = {
-        "state": vex_state,
         "detail": detail_string
     }
+    if vex_state:
+        analysis["state"] = vex_state
 
     # Add timestamps for CycloneDX 1.6+ when enabled
     # This provides better tracking of when vulnerabilities were identified and updated

--- a/classes/include/include-unpatched.inc
+++ b/classes/include/include-unpatched.inc
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+
+do_cyclonedx_package_collect[depends] += "${PN}:do_cve_check"
+do_cyclonedx_package_collect[nostamp] = "1"


### PR DESCRIPTION
Hi @Jasper-Ben,

thanks a lot for your fast response and general willingness to include the feature in PR https://github.com/iris-GmbH/meta-cyclonedx/pull/59. This commit implements the feature for `whinlatter` and has been tested with the `master` branches of [meta-yocto](https://git.yoctoproject.org/meta-yocto) and [openembedded-core](https://git.openembedded.org/openembedded-core).

Following your suggestions, I have added a description to the README that points out the limitation of querying the NVD at build time.

**Commit Description:**
This commit adds support for exporting unpatched vulnerabilities as supplied by `cve-check`. This feature is particularly useful for automated vulnerability triaging.

To this end, two variables are introduced:
- `CYCLONEDX_INCLUDE_UNPATCHED_VULNS`: By default, this variable is set to `0`, disabling the export of unpatched vulnerabilities. The default ensures that this feature does not change the behavior of the layer. When set to `1`, the `cve-check.bbclass` from Poky is inherited, so that the functionality from that class can be reused to fetch unpatched vulnerabilities from the NVD. These vulnerabilities are then appended to the VEX output.
- `CYCLONEDX_UNPATCHED_VULNS_STATE`: By default, this variable is set to `in_triage`. This enables the customization of the state field of the vulnerability analysis object in the VEX to match the vulnerability management process.