### PR TITLE
Add support for generating SBOM from non image.bbclass recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,45 @@ CYCLONEDX_INCLUDE_UNPATCHED_VULNS = "1"
 CYCLONEDX_UNPATCHED_VULNS_STATE = "in_triage"
 ```
 
+### Use with non-rootfs image recipes
+
+The default use of `cyclonedx-export.bbclass` only produces SBOM for recipes
+that inherits `image.bbclass`. In order to produce an SBOM for an image like
+recipe that does not generate a filesystem image, and thus not inherits
+`image.bbclass`, you can use the `CYCLONEDX_EXPORT_DEPENDS` variable to list the
+dependencies to consider/include. Something like this
+
+```sh
+CYCLONEDX_EXPORT_DEPENDS = "${DEPENDS}"
+```
+
+The dependencies will be filtered so that non-target recipes are excluded, and
+the remaining dependencies will be processed with `PREFERRED_PROVIDER_*`
+variables, so that you can include things like `virtual/bootloader` and
+`virtual/kernel`.
+
+Note: There is no recursion of `CYCLONEDX_EXPORT_DEPENDS`, so only the listed
+dependencies are included in the SBOM. So while this does allow using with any
+kind of recipe, it is in-practise mainly usable for simple compound images, like
+a bootloader image consisting of the output from a handful of recipes.
+
+In addition to settting `CYCLONEDX_EXPORT_DEPENDS` you will also need to hook up
+`do_populate_cyclonedx` and `do_deploy_cyclonedx` tasks. The
+`do_populate_cyclonedx` task should be added to `recrdeptask` flag on the recipe
+task that produces the image output, and the `do_deploy_cyclonedx` task should
+be added to the recipe.
+
+#### Example for producing SBOM for a genimage.bbclass recipe
+
+This is an example of how to produce SBOM for an image recipe using
+`genimage.bbclass` from [meta-ptx](https://github.com/pengutronix/meta-ptx):
+
+```sh
+CYCLONEDX_EXPORT_DEPENDS = "${DEPENDS}"
+do_genimage[recrdeptask] += "do_populate_cyclonedx"
+addtask do_deploy_cyclonedx after do_deploy before do_build
+```
+
 ## Usage
 
 Once everything is configured simply build your image as you normally would.

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -682,12 +682,42 @@ def append_to_vex(d, cve, cves, bom_ref):
     })
     return
 
+def list_runtime_recipes(d):
+    depends = (d.getVar("CYCLONEDX_EXPORT_DEPENDS") or "").split()
+    if depends:
+        return list_runtime_recipes_from_depends(d, depends)
+    else:
+        return list_runtime_recipes_from_packages(d)
+
+def list_runtime_recipes_from_packages(d):
+    from oe.rootfs import image_list_installed_packages
+    runtime_recipes = set()
+    for pkg in list(image_list_installed_packages(d)):
+        pkg_info = os.path.join(d.getVar('PKGDATA_DIR'),
+                                'runtime-reverse', pkg)
+        pkg_data = oe.packagedata.read_pkgdatafile(pkg_info)
+        runtime_recipes.add(pkg_data["PN"])
+    return runtime_recipes
+
+def list_runtime_recipes_from_depends(d, depends):
+    runtime_recipes = set()
+    ignored_suffixes = d.getVar("SPECIAL_PKGSUFFIX", "").split()
+    def runtime_recipe(dependency):
+        for ignored_suffix in ignored_suffixes:
+            if dependency.endswith(ignored_suffix):
+                return None
+        return d.getVar(f"PREFERRED_PROVIDER_{dependency}") or dependency
+    for dependency in depends:
+        recipe = runtime_recipe(dependency)
+        if recipe:
+            runtime_recipes.add(recipe)
+    return runtime_recipes
+
 python do_deploy_cyclonedx() {
     """
     Select CVE and package information and runtime packages and output them
     into a single export file.
     """
-    from oe.rootfs import image_list_installed_packages
     import uuid
     from datetime import datetime, timezone
     import os
@@ -744,12 +774,7 @@ python do_deploy_cyclonedx() {
     # Collect sbom data from runtime packages
 
     # Determine runtime packages for scope assignment
-    runtime_recipes = set()
-    for pkg in list(image_list_installed_packages(d)):
-        pkg_info = os.path.join(d.getVar('PKGDATA_DIR'),
-                                'runtime-reverse', pkg)
-        pkg_data = oe.packagedata.read_pkgdatafile(pkg_info)
-        runtime_recipes.add(pkg_data["PN"])
+    runtime_recipes = list_runtime_recipes(d)
 
     # Determine which recipes to include
     recipes = set()


### PR DESCRIPTION
For compound image recipes that does not use the image.bbclass infrastructure, this change provides a way to generate SBOM for their output also.

The new `CYCLONEDX_EXPORT_DEPENDS` variable serves multiple purposes.
1. By setting it, you declare that you want to use this alternative way of finding the SBOM content.
2. You can set it from different sources, not only `DEPENDS` variable, but also `depends` flags on one or more tasks.
3. You can filter out unwanted dependencies and add extra ones.