### PR TITLE
Fix cleaning of leftovers when previous builds

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -108,9 +108,13 @@ python () {
 # Clean out work folder to avoid leftovers from previous builds when including build-time package
 # information and a recipe was removed from the dependency list. (CYCLONEDX_RUNTIME_PACKAGES_ONLY set to 0)
 python clean_cyclonedx_work_folder() {
-    bb.note(f"Cleaning cyclonedx work folder {d.getVar('CYCLONEDX_WORK_DIR_ROOT')}")
+    import shutil
+    cyclonedx_work_dir_root = d.getVar('CYCLONEDX_WORK_DIR_ROOT')
+    bb.debug(f"Cleaning cyclonedx work folder {cyclonedx_work_dir_root}")
+    if os.path.exists(cyclonedx_work_dir_root):
+        shutil.rmtree(cyclonedx_work_dir_root)
+    bb.utils.mkdirhier(cyclonedx_work_dir_root)
 }
-clean_cyclonedx_work_folder[cleandirs] = "${CYCLONEDX_WORK_DIR_ROOT}"
 addhandler clean_cyclonedx_work_folder
 clean_cyclonedx_work_folder[eventmask] = "bb.event.BuildStarted"
 


### PR DESCRIPTION
The cleandirs flag is only valid for bitbake tasks, and does nothing for handler functions.

So we need to do the cleanup manually in the handler function instead.

In addition to the problems described in the comment before the function, switching between different MACHINE configurations in the same build dir was causing problems, such as this:

ERROR: mc:initramfs:perl-5.38.2-r0 do_populate_cyclonedx_setscene: Recipe perl is trying to install files into a shared area when those files already exist. The files and the manifests listing them are:
  /build/tmp-musl/cyclonedx/perl/pn-list.json
    (matched in manifest-cortexa53-crypto-perl.populate_cyclonedx)
Please adjust the recipes so only one recipe provides a given file. WARNING: Logfile for failed setscene task is /build/tmp-musl/work/core2-64-oe-linux-musl/perl/5.38.2/temp/log.do_populate_cyclonedx_setscene.1512710 WARNING: Setscene task (mc:initramfs:/src/oe-core/meta/recipes-devtools/perl/perl_5.38.2.bb:do_populate_cyclonedx_setscene) failed with exit code '1' - real task will be run instead

Fixes: d3a78c04785e ("Limit SBOM content to packages added to the rootfs")