### PR TITLE
cyclonedx-export.bbclass: fix a clean handler issue

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -60,10 +60,6 @@ CYCLONEDX_ADD_CITATION ??= "1"
 # See: https://www.cisa.gov/tlp
 CYCLONEDX_TLP_MARKING ??= ""
 
-CYCLONEDX_EXPORT_DIR ??= "${DEPLOY_DIR}/cyclonedx-export/${PN}"
-CYCLONEDX_EXPORT_DIR ??= "${DEPLOY_DIR}/cyclonedx-export/${IMAGE_BASENAME}"
-CYCLONEDX_EXPORT_SBOM ??= "${CYCLONEDX_EXPORT_DIR}/bom.json"
-CYCLONEDX_EXPORT_VEX ??= "${CYCLONEDX_EXPORT_DIR}/vex.json"
 CYCLONEDX_TMP_WORK_DIR ??= "${WORKDIR}/cyclonedx"
 CYCLONEDX_TMP_PN_LIST = "${CYCLONEDX_TMP_WORK_DIR}/pn-list.json"
 CYCLONEDX_WORK_DIR_ROOT ??= "${TMPDIR}/cyclonedx"
@@ -726,6 +722,7 @@ python do_deploy_cyclonedx() {
     """
     import uuid
     from datetime import datetime, timezone
+    from pathlib import Path
     import os
 
     timestamp = datetime.now(timezone.utc).isoformat()
@@ -916,10 +913,25 @@ python do_deploy_cyclonedx() {
                 affect["ref"] = affect["ref"].replace(
                     d.getVar('CYCLONEDX_SBOM_SERIAL_PLACEHOLDER'), sbom_serial_number)
 
-    write_json(d.getVar("CYCLONEDX_EXPORT_SBOM"), sbom)
-    write_json(d.getVar("CYCLONEDX_EXPORT_VEX"), vex)
+    image_name = d.getVar("IMAGE_NAME")
+    image_link_name = d.getVar("IMAGE_LINK_NAME")
+    imgdeploydir = Path(d.getVar("IMGDEPLOYDIR"))
+
+    image_sbom_path = imgdeploydir / (image_name + ".cyclonedx.sbom.json")
+    image_vex_path = imgdeploydir / (image_name + ".cyclonedx.vex.json")
+
+    write_json(image_sbom_path, sbom)
+    write_json(image_vex_path, vex)
+
+    def make_image_link(target_path, suffix):
+        if image_link_name:
+            link = imgdeploydir / (image_link_name + suffix)
+            if link != target_path:
+                link.symlink_to(os.path.relpath(target_path, link.parent))
+
+    make_image_link(image_sbom_path, ".cyclonedx.sbom.json")
+    make_image_link(image_vex_path, ".cyclonedx.vex.json")
 }
-do_deploy_cyclonedx[cleandirs] = "${CYCLONEDX_EXPORT_DIR}"
 
 # We use ROOTFS_POSTUNINSTALL_COMMAND to make sure this function runs exactly once
 # after the build process has been completed


### PR DESCRIPTION
A clean action on work directory is needed only when CYCLONEDX_RUNTIME_PACKAGES_ONLY is set to 0, let it behave so.

And we need let do_populate_cyclonedx depend on
CYCLONEDX_RUNTIME_PACKAGES_ONLY variable, otherwise, after the work directory be deleted, and the task stamp files already generated from a previous build, the sstate would not be re-installed and cause it exports empty json files in ${DEPLOY_DIR}/cyclonedx-export.