### PR TITLE
Fix multi-machine handling

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -71,7 +71,7 @@ IMAGE_LINK_NAME ??= ""
 CYCLONEDX_EXPORT_SBOM_LINK ??= "${@'${IMAGE_LINK_NAME}.cyclonedx.bom.json' if d.getVar('IMAGE_LINK_NAME') else ''}"
 CYCLONEDX_EXPORT_VEX_LINK ??= "${@'${IMAGE_LINK_NAME}.cyclonedx.vex.json' if d.getVar('IMAGE_LINK_NAME') else ''}"
 CYCLONEDX_PNDATA_WORKDIR = "${WORKDIR}/cyclonedx"
-CYCLONEDX_PNDATA = "${TMPDIR}/cyclonedx/pn/${MACHINE}"
+CYCLONEDX_PNDATA = "${TMPDIR}/cyclonedx/pn"
 CYCLONEDX_BUILDTIME_DIR = "${TMPDIR}/cyclonedx/buildtime"
 
 # We need to add the sbom serial number to the list of vulnerabilites for each recipe but
@@ -227,7 +227,8 @@ addtask do_populate_cyclonedx before do_build
 do_populate_cyclonedx[cleandirs] = "${CYCLONEDX_PNDATA_WORKDIR}"
 SSTATETASKS += "do_populate_cyclonedx"
 do_populate_cyclonedx[sstate-inputdirs] = "${CYCLONEDX_PNDATA_WORKDIR}"
-do_populate_cyclonedx[sstate-outputdirs] = "${CYCLONEDX_PNDATA}"
+do_populate_cyclonedx[sstate-outputdirs] = "${CYCLONEDX_PNDATA}/${SSTATE_PKGARCH}"
+do_populate_cyclonedx[vardeps] += "CYCLONEDX_PNDATA"
 python do_populate_cyclonedx_setscene() {
     sstate_setscene(d)
 }
@@ -786,11 +787,17 @@ def export_cyclonedx(d):
 
     image_recipe_names = set()
     pn_lists = {}
+    pkgarchs = d.getVar("SSTATE_ARCHS").split()
+    pkgarchs.reverse()
     # first loop to fill the dictionary
     for pkg in recipes:
-        pn_list_filepath = os.path.join(d.getVar("CYCLONEDX_PNDATA"), f"{pkg}.json")
+        for pkgarch in pkgarchs:
+            pn_list_filepath = os.path.join(d.getVar("CYCLONEDX_PNDATA"),
+                                            pkgarch, f"{pkg}.json")
+            if os.path.exists(pn_list_filepath):
+                break
         if not os.path.exists(pn_list_filepath):
-            bb.error(f"CycloneDX PN file not found: {pn_list_filepath}")
+            bb.error(f"CycloneDX PN file not found: {pkg}.json")
             continue
         pn_lists[pkg] = read_json(pn_list_filepath)
         pn_list = copy.deepcopy(pn_lists[pkg])
@@ -932,6 +939,7 @@ ROOTFS_POSTUNINSTALL_COMMAND =+ "do_export_cyclonedx; "
 SSTATETASKS += "do_deploy_cyclonedx"
 do_deploy_cyclonedx[sstate-inputdirs] = "${CYCLONEDX_TMP_EXPORT_DIR}"
 do_deploy_cyclonedx[sstate-outputdirs] = "${CYCLONEDX_EXPORT_DIR}"
+do_deploy_cyclonedx[vardeps] += "CYCLONEDX_EXPORT_DIR"
 python do_deploy_cyclonedx_setscene() {
     sstate_setscene(d)
 }


### PR DESCRIPTION
When building multiple machines, any "allarch" packages will not be rebuilt, so we need to place CycloneDX pn files so we can find them for other machines using them.

Writing to SSTATE_PKGARCH subdirectory allows using SSTATE_ARCHS when looking for the packages. The same approach is used in several places in oe-core for similar cases.

The vardeps flags are used to ensure that we rebuild when CYCLONEDX_PNDATA and/or CYCLONEDX_EXPORT_DIR is changed.