### PR TITLE
Run do_populate_cyclonedx when CVE_STATUS is modified

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -225,6 +225,7 @@ python do_populate_cyclonedx() {
 
 addtask do_populate_cyclonedx before do_build
 do_populate_cyclonedx[cleandirs] = "${CYCLONEDX_PNDATA_WORKDIR}"
+do_populate_cyclonedx[vardeps] += "CVE_STATUS"
 SSTATETASKS += "do_populate_cyclonedx"
 do_populate_cyclonedx[sstate-inputdirs] = "${CYCLONEDX_PNDATA_WORKDIR}"
 do_populate_cyclonedx[sstate-outputdirs] = "${CYCLONEDX_PNDATA}"


### PR DESCRIPTION
When a CVE_STATUS entry is added, removed, or modified in a recipe after an image has been built, this is not taken into account during the next build.

If this PR is merged, can it be backported to scarthgap branch please ?