### PR TITLE
Use correct check for buildtime marker files

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -774,7 +774,7 @@ def export_cyclonedx(d):
         recipes = runtime_recipes
     else:
         all_available = {pn for pn in os.listdir(cyclonedx_buildtime_dir)
-                        if os.path.isdir(os.path.join(cyclonedx_buildtime_dir, pn))}
+                        if os.path.exists(os.path.join(cyclonedx_buildtime_dir, pn))}
         recipes = all_available.union(runtime_recipes)
 
     # Create a bom_ref_map for dependencies sanitarization


### PR DESCRIPTION
Since commit ae021e4224c78580e7cc740f00f5679a3d4dfa45 (PR #71), buildtime recipes are recorded via marker files with `Path(…).touch()` in `CYCLONEDX_BUILDTIME_DIR`. However, `all_available` only keeps entries where `is.path.isdir(…)` is true. As the markers are files, not directories, `all_available` therefore becomes empty. The result is that the export falls back to `runtime_recipes` only.

This patch fixes that by checking for marker existence instead of type.