### PR TITLE
Allow extra runtime packages to be added to the SBOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ all build-time packages as well:
 CYCLONEDX_RUNTIME_PACKAGES_ONLY = "0"
 ```
 
+### Extra Runtime Recipes
+
+Some components are embedded directly into the image without going through the
+normal package installation process (e.g. OP-TEE compiled into a fitImage).
+Because these recipes do not produce rootfs packages, they are not detected by
+the standard runtime package discovery and would either be omitted (when
+`CYCLONEDX_RUNTIME_PACKAGES_ONLY = "1"`) or included only as build-time
+components with `scope = "optional"`/`"excluded"`.
+
+Use `CYCLONEDX_EXTRA_RUNTIME_RECIPES` to explicitly list such recipes so that
+they are always included in the SBOM with `scope = "required"`:
+
+```sh
+CYCLONEDX_EXTRA_RUNTIME_RECIPES = "optee-os trusted-firmware-a"
+```
+
+Multiple recipe names are separated by spaces. Each listed recipe must have
+already run `do_populate_cyclonedx` during the build, otherwise an error is
+raised and the recipe is skipped.
+
 ### Component Scopes
 
 When including both runtime and build-time packages, meta-cyclonedx uses
@@ -312,6 +332,10 @@ CYCLONEDX_INCLUDE_UNPATCHED_VULNS = "1"
 # State to assign to unpatched vulnerabilities (default: "in_triage").
 # Can be empty to omit the state field.
 CYCLONEDX_UNPATCHED_VULNS_STATE = "in_triage"
+
+# Space-separated list of recipes to always include with scope "required",
+# even if they do not produce rootfs packages (default: "").
+CYCLONEDX_EXTRA_RUNTIME_RECIPES = ""
 ```
 
 ### Use with non-rootfs image recipes

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -41,6 +41,11 @@ CYCLONEDX_UNPATCHED_VULNS_STATE ??= "in_triage"
 
 CYCLONEDX_RUNTIME_PACKAGES_ONLY ??= "1"
 
+# Space-separated list of recipe names to include in the SBOM regardless of
+# whether they produce rootfs packages. Use this for components that are
+# embedded directly into the image (e.g. OP-TEE inside a fitImage).
+CYCLONEDX_EXTRA_RUNTIME_RECIPES ??= ""
+
 # Add component licenses (as specified within the recipe) to the SBOM
 CYCLONEDX_ADD_COMPONENT_LICENSES ??= "1"
 
@@ -783,6 +788,10 @@ def export_cyclonedx(d):
                         if os.path.exists(os.path.join(cyclonedx_buildtime_dir, pn))}
         recipes = all_available.union(runtime_recipes)
 
+    # Always include explicitly requested recipes (e.g. optee-os embedded in fitImage)
+    extra_recipes = set((d.getVar('CYCLONEDX_EXTRA_RUNTIME_RECIPES') or '').split())
+    recipes = recipes.union(extra_recipes)
+
     # Create a bom_ref_map for dependencies sanitarization
     # And an alias_map to retrieve real pkg name
     bom_ref_map = {}
@@ -832,7 +841,7 @@ def export_cyclonedx(d):
             # Add scope field to indicate runtime vs build-time component
             # Can be disabled for certain SBOM profiles or tool compatibility
             if d.getVar('CYCLONEDX_ADD_COMPONENT_SCOPES') == "1":
-                pn_pkg["scope"] = "required" if pkg in runtime_recipes else "excluded"
+                pn_pkg["scope"] = "required" if pkg in runtime_recipes or pkg in extra_recipes else "excluded"
 
             sbom["components"].append(pn_pkg)
         for pn_cve in pn_list["cves"]:


### PR DESCRIPTION
Some components aren't installed into the rootfs, but may be built anyway. 
A couple of examples could be bootloaders and optee-os. This gives a way to add them inte the generated SBOM.

This has originally been tested against scarthgap, to implement #89.