### PR TITLE
cyclonedx-export: use SPDX_PACKAGE_URLS when set

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -543,12 +543,15 @@ def generate_packages_list(d, products_names, version):
         else:
             vendor = ""
 
+        spdx_purls = (d.getVar("SPDX_PACKAGE_URLS") or "").split()
+        purl = spdx_purls[0] if spdx_purls else get_base_purl(d)
+
         pkg = {
             "name": product,
             "version": version,
             "type": "library",
             "cpe": 'cpe:2.3:*:{}:{}:{}:*:*:*:*:*:*:*'.format(vendor or "*", product, version),
-            "purl": get_base_purl(d),
+            "purl": purl,
             "bom-ref": str(uuid.uuid4())
         }
         if vendor != "":


### PR DESCRIPTION
generate_packages_list() always uses purl from get_base_purl(), which produces a generic purl (pkg:yocto/...). This often does not match the package's canonical purl (pkg:pypi/...) and then matching against purl vulnerability databases does not work properly.

OE "create-spdx-3.0" already lets a recipe declare its canonical purls via SPDX_PACKAGE_URLS. When that variable is set, use its first entry so the CycloneDX output stays consistent with the SPDX SBOM for the same build.

When SPDX_PACKAGE_URLS is unset, fall back to get_base_purl().