### PR TITLE
Add CYCLONEDX_COMPONENT_PROPERTIES to attach custom properties to SBOM components

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ To disable this feature you can set
 CYCLONEDX_SPLIT_LICENSE_EXPRESSIONS = "0"
 ```
 
+### Component Properties
+
+The CycloneDX spec supports a `properties` array on components for arbitrary
+organization-specific metadata (e.g. downstream/vendor tagging). You can
+populate it per-recipe with a space-separated list of `name=value` pairs:
+
+```sh
+CYCLONEDX_COMPONENT_PROPERTIES = "custom:modified=true custom:team=platform"
+```
+
+Entries missing an `=` are skipped with a warning rather than failing the
+build. The variable is empty (no properties added) by default.
+
 ### CycloneDX 1.7 Optional Features
 
 When using CycloneDX 1.7, you can enable additional optional features for enhanced SBOM quality:
@@ -320,6 +333,10 @@ CYCLONEDX_ADD_COMPONENT_LICENSES = "1"
 # split license expressions into multiple license entries
 # when possible (default: "1")
 CYCLONEDX_SPLIT_LICENSE_EXPRESSIONS = "1"
+
+# Space-separated "name=value" pairs attached to this recipe's components
+# as a CycloneDX properties array (default: "").
+CYCLONEDX_COMPONENT_PROPERTIES = ""
 
 # CycloneDX 1.7 optional features
 CYCLONEDX_ADD_LICENSE_DETAILS = "1"  # Include license text for custom licenses

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -42,6 +42,15 @@ CYCLONEDX_EXTRA_RUNTIME_RECIPES ??= ""
 # Add component licenses (as specified within the recipe) to the SBOM
 CYCLONEDX_ADD_COMPONENT_LICENSES ??= "1"
 
+# Space-separated list of "name=value" pairs to attach to this recipe's
+# components as a CycloneDX properties array (e.g. downstream/vendor tagging
+# such as `seco:modified=true`). Empty by default (no properties added).
+# NOTE: this must be a plain string value, not a bitbake variable flag —
+# flag names cannot contain ":" (see bitbake's ConfHandler flag regex), so
+# CYCLONEDX_COMPONENT_PROPERTIES[foo:bar] = "..." is invalid syntax and will
+# fail to parse.
+CYCLONEDX_COMPONENT_PROPERTIES ??= ""
+
 # Optionally, split simple license expressions (only containing "AND") into multiple licenses.
 CYCLONEDX_SPLIT_LICENSE_EXPRESSIONS ??= "1"
 
@@ -149,6 +158,10 @@ python do_populate_cyclonedx() {
             else:
                 bb.warn(f"LICENSE variable not set for package {pn}")
 
+        custom_properties = get_custom_properties(d)
+        if custom_properties:
+            pkg["properties"] = custom_properties
+
         pn_list["pkgs"].append(pkg)
         bom_ref = pkg["bom-ref"]
 
@@ -204,6 +217,7 @@ SSTATETASKS += "do_populate_cyclonedx"
 do_populate_cyclonedx[sstate-inputdirs] = "${CYCLONEDX_PNDATA_WORKDIR}"
 do_populate_cyclonedx[sstate-outputdirs] = "${CYCLONEDX_PNDATA}/${SSTATE_PKGARCH}"
 do_populate_cyclonedx[vardeps] += "CYCLONEDX_PNDATA"
+do_populate_cyclonedx[vardeps] += "CYCLONEDX_COMPONENT_PROPERTIES"
 python do_populate_cyclonedx_setscene() {
     sstate_setscene(d)
 }
@@ -395,6 +409,23 @@ def resolve_license_data(d):
             license_info[-1]["license"]["acknowledgement"] = "declared"
 
     return license_info
+
+def get_custom_properties(d):
+    """
+    Parse CYCLONEDX_COMPONENT_PROPERTIES ("name=value" entries, space separated)
+    into a CycloneDX properties array: [{"name": ..., "value": ...}, ...].
+
+    Malformed entries (missing "=") are skipped with a warning rather than
+    failing the build, since a typo here shouldn't break SBOM generation.
+    """
+    properties = []
+    for entry in (d.getVar("CYCLONEDX_COMPONENT_PROPERTIES") or "").split():
+        name, sep, value = entry.partition("=")
+        if not sep:
+            bb.warn(f"Ignoring malformed CYCLONEDX_COMPONENT_PROPERTIES entry (expected name=value): {entry}")
+            continue
+        properties.append({"name": name, "value": value})
+    return properties
 
 def create_tools_metadata(d):
     """


### PR DESCRIPTION
The CycloneDX spec supports a properties array on components for arbitrary organization-specific metadata, but there was no way to populate it from a recipe. Add a per-recipe CYCLONEDX_COMPONENT_PROPERTIES variable (space-separated name=value pairs, empty by default) that do_populate_cyclonedx parses into that array and attaches to the component, and register it in do_populate_cyclonedx[vardeps] for correct sstate invalidation.

Closes #104.