### PR TITLE
Fix: Adding support for image-level dependencies

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -731,7 +731,6 @@ def export_cyclonedx(d):
         "timestamp": timestamp,
         "tools": create_tools_metadata(d)
     }
-    add_metadata_extensions(d, sbom_metadata)
     sbom_metadata["component"] = {
         "type": "firmware",
         "name": image_name,


### PR DESCRIPTION
I think the line `add_metadata_extensions(d, sbom_metadata)` was accidentaly backported from commit 21473dad9714f4f78e3f54421511e398261c9b52 ("Add CycloneDX 1.7 support (backward compatible)").

This leads to error:
```
File: 'meta-cyclonedx/classes/cyclonedx-export.bbclass', lineno: 986, function: do_export_cyclonedx                                  08:12:52 [57/416]
     0982:    make_deploy_symlink(export_sbom, get_cyclonedx_export_path("CYCLONEDX_EXPORT_SBOM_LINK"))                                                                               
     0983:    make_deploy_symlink(export_vex, get_cyclonedx_export_path("CYCLONEDX_EXPORT_VEX_LINK"))                                                                                 
     0984:                                                                                 
     0985:python do_export_cyclonedx() {                                                                                                                                              
 *** 0986:    export_cyclonedx(d)                                                                                                                                                     
     0987:}                                                                                                                                                                           
     0988:                                                                                                                                                                            
     0989:# We use ROOTFS_POSTUNINSTALL_COMMAND to make sure this function runs exactly once                                                                                          
     0990:# after the build process has been completed                                                                                                                                
File: 'meta-cyclonedx/classes/cyclonedx-export.bbclass', lineno: 737, function: export_cyclonedx                                                      
     0733:    sbom_metadata = {                                                                                                                                                       
     0734:        "timestamp": timestamp,                                                                                                                                             
     0735:        "tools": create_tools_metadata(d)
     0736:    }
 *** 0737:    add_metadata_extensions(d, sbom_metadata)
     0738:    sbom_metadata["component"] = {
     0739:        "type": "firmware",
     0740:        "name": image_name,
     0741:        "version": image_version,
Exception: NameError: name 'add_metadata_extensions' is not defined
```

Removing this line seems to fix the cause.