### PR TITLE
cyclonedx-export: merge recipe-provided CycloneDX documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ BBLAYERS += "${BSPDIR}/sources/meta-cyclonedx"
 
 ## Configuration
 
+> **:warning: Breaking change when upgrading to Wrynose or later:**
+> Starting with Wrynose the `CYCLONEDX_INCLUDE_UNPATCHED_VULNS` option is not
+> available. For more details, see [this issue](https://github.com/iris-GmbH/meta-cyclonedx/issues/97)
+
 To enable and configure the layer simply inherit the `cyclonedx-export` class
 in your `local.conf` file:
 
@@ -321,17 +325,6 @@ CYCLONEDX_SPLIT_LICENSE_EXPRESSIONS = "1"
 CYCLONEDX_ADD_LICENSE_DETAILS = "1"  # Include license text for custom licenses
 CYCLONEDX_ADD_CITATION = "1"         # Document SBOM provenance
 CYCLONEDX_TLP_MARKING = ""           # TLP marking (CLEAR|GREEN|AMBER|AMBER_STRICT|RED)
-
-# Include unpatched vulnerabilities in VEX (default: "0").
-# If enabled, the cve-check class is inherited to query the NVD.
-# Note that querying the NVD happens at the time of running the
-# task, which currently requires rootfs generation. You may
-# want to use external tools such as DependencyTrack for regular analysis.
-CYCLONEDX_INCLUDE_UNPATCHED_VULNS = "1"
-
-# State to assign to unpatched vulnerabilities (default: "in_triage").
-# Can be empty to omit the state field.
-CYCLONEDX_UNPATCHED_VULNS_STATE = "in_triage"
 
 # Space-separated list of recipes to always include with scope "required",
 # even if they do not produce rootfs packages (default: "").

--- a/README.md
+++ b/README.md
@@ -413,19 +413,12 @@ e.g. as part of a CI job that runs after your build is complete.
 
 This is possible by leveraging DependencyTracks REST API.
 
-At the time of writing this can be done by leveraging the following API
-endpoints:
-
-1. `/v1/bom` for uploading the `bom.json`.
-2. `/v1/event/token/{uuid}` for checking the status on the `bom.json`
-   processing.
-3. `/v1/vex` for uploading the `vex.json`.
-
 Please refer to [DependencyTracks REST API documentation](https://docs.dependencytrack.org/integrations/rest-api/)
 regarding the usage of these endpoints as well as the required token
 permissions.
 
-In the future we might include an example script in this repository.
+An example python script can be found at
+`examples/automated-dependencytrack-upload.py` and may be freely used (CC0-1.0).
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ all build-time packages as well:
 CYCLONEDX_RUNTIME_PACKAGES_ONLY = "0"
 ```
 
+### Extra Runtime Recipes
+
+Some components are embedded directly into the image without going through the
+normal package installation process (e.g. OP-TEE compiled into a fitImage).
+Because these recipes do not produce rootfs packages, they are not detected by
+the standard runtime package discovery and would either be omitted (when
+`CYCLONEDX_RUNTIME_PACKAGES_ONLY = "1"`) or included only as build-time
+components with `scope = "optional"`/`"excluded"`.
+
+Use `CYCLONEDX_EXTRA_RUNTIME_RECIPES` to explicitly list such recipes so that
+they are always included in the SBOM with `scope = "required"`:
+
+```sh
+CYCLONEDX_EXTRA_RUNTIME_RECIPES = "optee-os trusted-firmware-a"
+```
+
+Multiple recipe names are separated by spaces. Each listed recipe must have
+already run `do_populate_cyclonedx` during the build, otherwise an error is
+raised and the recipe is skipped.
+
 ### Component Scopes
 
 When including both runtime and build-time packages, meta-cyclonedx uses
@@ -312,6 +332,10 @@ CYCLONEDX_INCLUDE_UNPATCHED_VULNS = "1"
 # State to assign to unpatched vulnerabilities (default: "in_triage").
 # Can be empty to omit the state field.
 CYCLONEDX_UNPATCHED_VULNS_STATE = "in_triage"
+
+# Space-separated list of recipes to always include with scope "required",
+# even if they do not produce rootfs packages (default: "").
+CYCLONEDX_EXTRA_RUNTIME_RECIPES = ""
 ```
 
 ### Use with non-rootfs image recipes

--- a/README.md
+++ b/README.md
@@ -133,6 +133,55 @@ Multiple recipe names are separated by spaces. Each listed recipe must have
 already run `do_populate_cyclonedx` during the build, otherwise an error is
 raised and the recipe is skipped.
 
+### Recipe-contributed CycloneDX Fragments
+
+Language ecosystems that resolve their own dependency trees — cargo, npm, go —
+are invisible to Yocto's package model. The image BOM lists the recipe that
+builds the binary, but not the modules linked into it, so a Rust service appears
+as a single component while the crates it depends on (and their advisories) are
+missing.
+
+A recipe can close that gap by generating a CycloneDX document at build time and
+pointing `CYCLONEDX_EXTRA_BOM_FILES` at it:
+
+```sh
+CYCLONEDX_EXTRA_BOM_FILES = "${B}/cargo-cyclonedx.json"
+```
+
+Multiple documents are separated by spaces. Each file is read during
+`do_populate_cyclonedx`, so it must already exist by then — a recipe that
+generates the document while building should order the task accordingly:
+
+```sh
+addtask do_populate_cyclonedx after do_compile
+```
+
+The components and dependency edges are merged into the image BOM verbatim.
+They already carry their own bom-refs, purls and dependency edges, so the CPE
+deduplication and the recipe-name dependency remapping applied to Yocto-derived
+components are deliberately skipped — those would corrupt an externally
+resolved tree. Duplicate `bom-ref`s (the same crate pulled in by two recipes)
+are dropped, keeping the first occurrence.
+
+The document's own root — `metadata.component`, the module the recipe builds —
+is carried over as a component too, and a dependency edge is added from the
+contributing recipe's component to it. The resulting tree therefore hangs off
+the package it belongs to:
+
+```
+ripgrep (pkg:yocto)          the recipe, as discovered by Yocto
+└── ripgrep (metadata.component of the contributed document)
+    └── regex (pkg:cargo) → aho-corasick (pkg:cargo) → …
+```
+
+Both steps are needed: CycloneDX does not repeat `metadata.component` inside
+`components`, yet the document's dependency edges reference it, so without
+them the merged tree would hang off an unresolvable bom-ref and the modules
+would float unattributed at the top level of the BOM.
+
+A missing or unparsable file produces a warning and is skipped, so a build does
+not fail because a language ecosystem could not emit its SBOM.
+
 ### Component Scopes
 
 When including both runtime and build-time packages, meta-cyclonedx uses

--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ CYCLONEDX_SPEC_VERSION = "1.6"  # Default - modern format
 - **1.6**: Modern format with enhanced metadata and timestamps (default)
 - **1.7**: Latest version with advanced cryptography transparency (CBOM), intellectual property visibility, citations, and improved custom license handling
 
+### Image Component Version
+
+The generated SBOM includes a top-level image component in metadata. Its version
+value is controlled by CYCLONEDX_IMAGE_VERSION.
+
+By default, this is derived from Yocto's distro/image version variables:
+
+```sh
+CYCLONEDX_IMAGE_VERSION = "${DISTRO_VERSION}${IMAGE_VERSION_SUFFIX}"
+```
+
+You can override it to match your release process (for example, a semantic
+version, CI build number, or git tag):
+
+```sh
+CYCLONEDX_IMAGE_VERSION = "2026.07.0"
+```
+
 ### Runtime vs Build-time Packages
 
 By default, meta-cyclonedx will only include run-time packages in the SBOM,
@@ -304,6 +322,10 @@ This produces the smallest valid CycloneDX SBOM with only essential vulnerabilit
 ```sh
 # Specification version (default: "1.6")
 CYCLONEDX_SPEC_VERSION = "1.6"  # or "1.7" or "1.4"
+
+# Version for metadata.component in the generated SBOM
+# (default: "${DISTRO_VERSION}${IMAGE_VERSION_SUFFIX}")
+CYCLONEDX_IMAGE_VERSION = "${DISTRO_VERSION}${IMAGE_VERSION_SUFFIX}"
 
 # Include build-time packages (default: "1" = runtime only)
 CYCLONEDX_RUNTIME_PACKAGES_ONLY = "1"

--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ To disable this feature you can set
 CYCLONEDX_SPLIT_LICENSE_EXPRESSIONS = "0"
 ```
 
+### Component Properties
+
+The CycloneDX spec supports a `properties` array on components for arbitrary
+organization-specific metadata (e.g. downstream/vendor tagging). You can
+populate it per-recipe with a space-separated list of `name=value` pairs:
+
+```sh
+CYCLONEDX_COMPONENT_PROPERTIES = "custom:modified=true custom:team=platform"
+```
+
+Entries missing an `=` are skipped with a warning rather than failing the
+build. The variable is empty (no properties added) by default.
+
 ### CycloneDX 1.7 Optional Features
 
 When using CycloneDX 1.7, you can enable additional optional features for enhanced SBOM quality:
@@ -342,6 +355,10 @@ CYCLONEDX_ADD_COMPONENT_LICENSES = "1"
 # split license expressions into multiple license entries
 # when possible (default: "1")
 CYCLONEDX_SPLIT_LICENSE_EXPRESSIONS = "1"
+
+# Space-separated "name=value" pairs attached to this recipe's components
+# as a CycloneDX properties array (default: "").
+CYCLONEDX_COMPONENT_PROPERTIES = ""
 
 # CycloneDX 1.7 optional features
 CYCLONEDX_ADD_LICENSE_DETAILS = "1"  # Include license text for custom licenses

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -41,6 +41,11 @@ CYCLONEDX_UNPATCHED_VULNS_STATE ??= "in_triage"
 
 CYCLONEDX_RUNTIME_PACKAGES_ONLY ??= "1"
 
+# Space-separated list of recipe names to include in the SBOM regardless of
+# whether they produce rootfs packages. Use this for components that are
+# embedded directly into the image (e.g. OP-TEE inside a fitImage).
+CYCLONEDX_EXTRA_RUNTIME_RECIPES ??= ""
+
 # Add component licenses (as specified within the recipe) to the SBOM
 CYCLONEDX_ADD_COMPONENT_LICENSES ??= "1"
 
@@ -783,6 +788,10 @@ def export_cyclonedx(d):
                         if os.path.exists(os.path.join(cyclonedx_buildtime_dir, pn))}
         recipes = all_available.union(runtime_recipes)
 
+    # Always include explicitly requested recipes (e.g. optee-os embedded in fitImage)
+    extra_recipes = set((d.getVar('CYCLONEDX_EXTRA_RUNTIME_RECIPES') or '').split())
+    recipes = recipes.union(extra_recipes)
+
     # Create a bom_ref_map for dependencies sanitarization
     # And an alias_map to retrieve real pkg name
     bom_ref_map = {}
@@ -832,7 +841,7 @@ def export_cyclonedx(d):
             # Add scope field to indicate runtime vs build-time component
             # Can be disabled for certain SBOM profiles or tool compatibility
             if d.getVar('CYCLONEDX_ADD_COMPONENT_SCOPES') == "1":
-                pn_pkg["scope"] = "required" if pkg in runtime_recipes else "excluded"
+                pn_pkg["scope"] = "required" if pkg in runtime_recipes or pkg in extra_recipes else "excluded"
 
             sbom["components"].append(pn_pkg)
         for pn_cve in pn_list["cves"]:

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -543,12 +543,15 @@ def generate_packages_list(d, products_names, version):
         else:
             vendor = ""
 
+        spdx_purls = (d.getVar("SPDX_PACKAGE_URLS") or "").split()
+        purl = spdx_purls[0] if spdx_purls else get_base_purl(d)
+
         pkg = {
             "name": product,
             "version": version,
             "type": "library",
             "cpe": 'cpe:2.3:*:{}:{}:{}:*:*:*:*:*:*:*'.format(vendor or "*", product, version),
-            "purl": get_base_purl(d),
+            "purl": purl,
             "bom-ref": str(uuid.uuid4())
         }
         if vendor != "":

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -28,13 +28,6 @@ CYCLONEDX_ADD_COMPONENT_SCOPES ??= "1"
 # Available in CycloneDX 1.6
 CYCLONEDX_ADD_VULN_TIMESTAMPS ??= "1"
 
-# Include unpatched vulnerabilities in VEX.
-# If enabled, the cve-check class is inherited to query the NVD.
-# Note that querying the NVD happens at the time of running the
-# task, which currently requires rootfs generation. You may
-# want to use external tools for regular analysis.
-CYCLONEDX_INCLUDE_UNPATCHED_VULNS ??= "0"
-
 # State to assign to unpatched vulnerabilities.
 # Can be empty to omit the state field.
 CYCLONEDX_UNPATCHED_VULNS_STATE ??= "in_triage"
@@ -83,10 +76,6 @@ CYCLONEDX_BUILDTIME_DIR = "${TMPDIR}/cyclonedx/buildtime"
 # don't know it until after we generate the sbom export header file
 CYCLONEDX_SBOM_SERIAL_PLACEHOLDER = "<SBOM_SERIAL>"
 
-# If unpatched vulnerabilities are to be included, we need to inherit the cve-check class.
-# This is because we rely on the `check_cves` function from that class to query the NVD.
-inherit_defer ${@ "cve-check" if d.getVar("CYCLONEDX_INCLUDE_UNPATCHED_VULNS") == "1" else ""}
-
 python () {
     from oe.cve_check import extend_cve_status
 
@@ -97,6 +86,9 @@ python () {
     spec_version = d.getVar("CYCLONEDX_SPEC_VERSION")
     if spec_version not in ["1.4", "1.6", "1.7"]:
         bb.fatal(f"Unsupported CYCLONEDX_SPEC_VERSION: {spec_version}. Supported versions: 1.4, 1.6, 1.7")
+
+    if d.getVar("CYCLONEDX_INCLUDE_UNPATCHED_VULNS") == "1":
+        bb.warn(f"meta-cyclonedx: Option CYCLONEDX_INCLUDE_UNPATCHED_VULNS has been removed post-Wrynose")
 }
 
 # Clean out buildtime dir to prepare for creating complete list of build-time package information
@@ -171,29 +163,6 @@ python do_populate_cyclonedx() {
             )
             append_to_vex(d, cve, cves, bom_ref)
 
-        # The check_cves function is coming from the cve-check class
-        # that we conditionally inherit to query the NVD.
-        if d.getVar("CYCLONEDX_INCLUDE_UNPATCHED_VULNS") == "1" and os.path.exists(d.getVar("CVE_CHECK_DB_FILE")):
-            with bb.utils.fileslocked([d.getVar("CVE_CHECK_DB_FILE_LOCK")], shared=True):
-                bb.debug(2, f"Querying CVE database for unpatched CVEs for package {pn}")
-
-                # Turn off warnings and restore afterwards
-                cve_check_show_warnings_original = d.getVar("CVE_CHECK_SHOW_WARNINGS")
-                d.setVar("CVE_CHECK_SHOW_WARNINGS", "0")
-                cve_data, _ = check_cves(d, patched_cves)
-                d.setVar("CVE_CHECK_SHOW_WARNINGS", cve_check_show_warnings_original)
-
-                unpatched_cve_ids = [cve_id for cve_id, data in cve_data.items() if data["abbrev-status"] == "Unpatched"]
-                bb.debug(2, f"Found {len(unpatched_cve_ids)} unpatched CVEs for package {pn}")
-                for cve_id in unpatched_cve_ids:
-                    cve = (
-                        cve_id,
-                        "Unpatched",
-                        "no-fix-supplied",
-                        ""
-                    )
-                    append_to_vex(d, cve, cves, bom_ref)
-
     # append any cve status within recipe to pn_list cves
     pn_list["cves"] = cves
 
@@ -239,10 +208,6 @@ python do_populate_cyclonedx_setscene() {
     sstate_setscene(d)
 }
 addtask do_populate_cyclonedx_setscene
-
-# We cannot set nostamp on do_populate_cyclonedx conditionally due to YP bug #13808.
-# Instead, we conditionally include a file.
-require ${@ "include/include-unpatched.inc" if d.getVar("CYCLONEDX_INCLUDE_UNPATCHED_VULNS") == "1" else ""}
 
 do_rootfs[recrdeptask] += "do_populate_cyclonedx"
 
@@ -620,8 +585,6 @@ def append_to_vex(d, cve, cves, bom_ref):
     # Normalize CVE ID to remove patch file suffixes (e.g., CVE-2025-52886-0001 -> CVE-2025-52886)
     normalized_cve_id = normalize_cve_id(cve_id)
 
-    include_unpatched = d.getVar("CYCLONEDX_INCLUDE_UNPATCHED_VULNS") == "1"
-
     # See https://docs.yoctoproject.org/singleindex.html#term-CVE_CHECK_STATUSMAP for possible statuses.
     if abbrev_status == "Patched":
         bb.debug(2, f"Found patch for {normalized_cve_id} in {d.getVar('BPN')}")
@@ -629,9 +592,6 @@ def append_to_vex(d, cve, cves, bom_ref):
     elif abbrev_status == "Ignored":
         bb.debug(2, f"Found ignore statement for {normalized_cve_id} in {d.getVar('BPN')}")
         vex_state = "not_affected"
-    elif abbrev_status == "Unpatched" and include_unpatched:
-        bb.debug(2, f"Found unpatched status for {normalized_cve_id} in {d.getVar('BPN')}")
-        vex_state = d.getVar("CYCLONEDX_UNPATCHED_VULNS_STATE")
     else:
         bb.debug(2, f"Found unknown or irrelevant CVE status {abbrev_status} for {normalized_cve_id} in {d.getVar('BPN')}. Skipping...")
         return

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -890,12 +890,12 @@ def export_cyclonedx(d):
         path = d.getVar(path_variable_name)
         if not path:
             if required:
-                bb.error(f"{var} must be set")
+                bb.error(f"{path_variable_name} must be set")
             else:
                 return path
         if os.path.isabs(path):
             if not path.startswith(export_dir):
-                bb.error(var + " must be a relative path or start with ${CYCLONEDX_EXPORT_DIR})")
+                bb.error(path_variable_name + " must be a relative path or start with ${CYCLONEDX_EXPORT_DIR}")
             else:
                 path = Path(path).relative_to(export_dir)
         path = os.path.join(tmp_export_dir, path)

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -789,7 +789,18 @@ def export_cyclonedx(d):
         recipes = all_available.union(runtime_recipes)
 
     # Always include explicitly requested recipes (e.g. optee-os embedded in fitImage)
-    extra_recipes = set((d.getVar('CYCLONEDX_EXTRA_RUNTIME_RECIPES') or '').split())
+    # Resolve virtual/* entries via PREFERRED_PROVIDER_*
+    extra_recipes = set()
+    for recipe in (d.getVar('CYCLONEDX_EXTRA_RUNTIME_RECIPES') or '').split():
+        if recipe.startswith("virtual/"):
+            resolved = (d.getVar("PREFERRED_RPROVIDER_" + recipe)
+                        or d.getVar("PREFERRED_PROVIDER_" + recipe))
+            if not resolved:
+                bb.warn(f"CYCLONEDX_EXTRA_RUNTIME_RECIPES: no provider for {recipe}, skipping")
+                continue
+            bb.debug(2, f"CYCLONEDX_EXTRA_RUNTIME_RECIPES: resolved {recipe} -> {resolved}")
+            recipe = resolved
+        extra_recipes.add(recipe)
     recipes = recipes.union(extra_recipes)
 
     # Create a bom_ref_map for dependencies sanitarization

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -45,6 +45,15 @@ CYCLONEDX_EXTRA_RUNTIME_RECIPES ??= ""
 # Add component licenses (as specified within the recipe) to the SBOM
 CYCLONEDX_ADD_COMPONENT_LICENSES ??= "1"
 
+# Space-separated list of "name=value" pairs to attach to this recipe's
+# components as a CycloneDX properties array (e.g. downstream/vendor tagging
+# such as `seco:modified=true`). Empty by default (no properties added).
+# NOTE: this must be a plain string value, not a bitbake variable flag —
+# flag names cannot contain ":" (see bitbake's ConfHandler flag regex), so
+# CYCLONEDX_COMPONENT_PROPERTIES[foo:bar] = "..." is invalid syntax and will
+# fail to parse.
+CYCLONEDX_COMPONENT_PROPERTIES ??= ""
+
 # Optionally, split simple license expressions (only containing "AND") into multiple licenses.
 CYCLONEDX_SPLIT_LICENSE_EXPRESSIONS ??= "1"
 
@@ -152,6 +161,10 @@ python do_populate_cyclonedx() {
             else:
                 bb.warn(f"LICENSE variable not set for package {pn}")
 
+        custom_properties = get_custom_properties(d)
+        if custom_properties:
+            pkg["properties"] = custom_properties
+
         pn_list["pkgs"].append(pkg)
         bom_ref = pkg["bom-ref"]
 
@@ -207,6 +220,7 @@ SSTATETASKS += "do_populate_cyclonedx"
 do_populate_cyclonedx[sstate-inputdirs] = "${CYCLONEDX_PNDATA_WORKDIR}"
 do_populate_cyclonedx[sstate-outputdirs] = "${CYCLONEDX_PNDATA}/${SSTATE_PKGARCH}"
 do_populate_cyclonedx[vardeps] += "CYCLONEDX_PNDATA"
+do_populate_cyclonedx[vardeps] += "CYCLONEDX_COMPONENT_PROPERTIES"
 python do_populate_cyclonedx_setscene() {
     sstate_setscene(d)
 }
@@ -398,6 +412,23 @@ def resolve_license_data(d):
             license_info[-1]["license"]["acknowledgement"] = "declared"
 
     return license_info
+
+def get_custom_properties(d):
+    """
+    Parse CYCLONEDX_COMPONENT_PROPERTIES ("name=value" entries, space separated)
+    into a CycloneDX properties array: [{"name": ..., "value": ...}, ...].
+
+    Malformed entries (missing "=") are skipped with a warning rather than
+    failing the build, since a typo here shouldn't break SBOM generation.
+    """
+    properties = []
+    for entry in (d.getVar("CYCLONEDX_COMPONENT_PROPERTIES") or "").split():
+        name, sep, value = entry.partition("=")
+        if not sep:
+            bb.warn(f"Ignoring malformed CYCLONEDX_COMPONENT_PROPERTIES entry (expected name=value): {entry}")
+            continue
+        properties.append({"name": name, "value": value})
+    return properties
 
 def create_tools_metadata(d):
     """

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -34,6 +34,9 @@ CYCLONEDX_UNPATCHED_VULNS_STATE ??= "in_triage"
 
 CYCLONEDX_RUNTIME_PACKAGES_ONLY ??= "1"
 
+# Version string for metadata.component in the CycloneDX SBOM.
+CYCLONEDX_IMAGE_VERSION ??= "${DISTRO_VERSION}${IMAGE_VERSION_SUFFIX}"
+
 # Space-separated list of recipe names to include in the SBOM regardless of
 # whether they produce rootfs packages. Use this for components that are
 # embedded directly into the image (e.g. OP-TEE inside a fitImage).
@@ -663,6 +666,85 @@ def list_runtime_recipes_from_packages(d):
         runtime_recipes.add(pkg_data["PN"])
     return runtime_recipes
 
+def list_image_install_recipes(d):
+    """
+    Return recipe names for packages explicitly requested in IMAGE_INSTALL.
+    """
+    image_install = d.expand(d.getVar("IMAGE_INSTALL") or "").split()
+    recipes = set()
+
+    def resolve_and_record(pkg_token):
+        recipe = _resolve_runtime_token_to_recipe(d, pkg_token)
+        if recipe:
+            recipes.add(recipe)
+        return recipe
+
+    for token in image_install:
+        if not token:
+            continue
+
+        root_recipe = resolve_and_record(token)
+        if not root_recipe:
+            bb.debug(2, f"Could not map IMAGE_INSTALL package '{token}' to a recipe token")
+            continue
+
+        # If IMAGE_INSTALL contains a packagegroup, treat packages brought in by
+        # that packagegroup as direct image-install components too.
+        if root_recipe.startswith("packagegroup-"):
+            queue = [token]
+            seen_pkg_tokens = set()
+
+            while queue:
+                current_pkg_token = queue.pop(0)
+                if current_pkg_token in seen_pkg_tokens:
+                    continue
+                seen_pkg_tokens.add(current_pkg_token)
+
+                for dep_pkg in _read_runtime_package_rdepends(d, current_pkg_token):
+                    dep_recipe = resolve_and_record(dep_pkg)
+                    if dep_recipe and dep_recipe.startswith("packagegroup-") and dep_pkg not in seen_pkg_tokens:
+                        queue.append(dep_pkg)
+
+    return recipes
+
+def _resolve_runtime_token_to_recipe(d, token):
+    """
+    Resolve a package/runtime token (or virtual/* token) to recipe PN.
+    """
+    pkg_info = os.path.join(d.getVar('PKGDATA_DIR'), 'runtime-reverse', token)
+    if os.path.exists(pkg_info):
+        pkg_data = oe.packagedata.read_pkgdatafile(pkg_info)
+        return pkg_data.get("PN")
+
+    if token.startswith("virtual/"):
+        return d.getVar("PREFERRED_RPROVIDER_" + token) or d.getVar("PREFERRED_PROVIDER_" + token)
+
+    return None
+
+def _read_runtime_package_rdepends(d, pkg):
+    """
+    Read runtime dependencies of a package token from pkgdata/runtime.
+    """
+    pkg_runtime_info = os.path.join(d.getVar('PKGDATA_DIR'), 'runtime', pkg)
+    if not os.path.exists(pkg_runtime_info):
+        return []
+
+    pkg_data = oe.packagedata.read_pkgdatafile(pkg_runtime_info)
+    # pkgdata stores package-scoped dependency keys (e.g. RDEPENDS:busybox).
+    # Fall back to plain RDEPENDS for compatibility with possible format changes.
+    raw_rdepends = pkg_data.get(f"RDEPENDS:{pkg}") or pkg_data.get("RDEPENDS") or ""
+
+    # pkgdata may include version constraints and alternation markers.
+    # Keep the plain dependency tokens only.
+    deps = []
+    for dep in raw_rdepends.replace("|", " ").split():
+        if dep in ["(", ")", "=", ">=", "<=", ">", "<", "|"]:
+            continue
+        dep = dep.split("(", 1)[0].strip()
+        if dep:
+            deps.append(dep)
+    return deps
+
 def list_runtime_recipes_from_depends(d, depends):
     runtime_recipes = set()
     ignored_suffixes = d.getVar("SPECIAL_PKGSUFFIX", "").split()
@@ -690,6 +772,10 @@ def export_cyclonedx(d):
 
     timestamp = datetime.now(timezone.utc).isoformat()
 
+    image_name = d.getVar("IMAGE_BASENAME") or d.getVar("PN") or "image"
+    image_version = d.getVar("CYCLONEDX_IMAGE_VERSION") or "unknown"
+    metadata_component_ref = str(uuid.uuid4())
+
     # Generate unique serial numbers for sbom and vex document
     sbom_serial_number = str(uuid.uuid4())
     vex_serial_number = str(uuid.uuid4())
@@ -706,6 +792,12 @@ def export_cyclonedx(d):
         "tools": create_tools_metadata(d)
     }
     add_metadata_extensions(d, sbom_metadata)
+    sbom_metadata["component"] = {
+        "type": "firmware",
+        "name": image_name,
+        "version": image_version,
+        "bom-ref": metadata_component_ref
+    }
 
     sbom = {
         "bomFormat": "CycloneDX",
@@ -716,6 +808,12 @@ def export_cyclonedx(d):
         "components": [],
         "dependencies": []
     }
+
+    # Only supported from CycloneDX 1.5.
+    if spec_version != "1.4":
+        sbom["metadata"]["lifecycles"] = [
+            {"phase": "build"}
+        ]
 
     # Generate vex document header
     bb.debug(2, f"Creating empty temporary vex file with serial number {sbom_serial_number}")
@@ -742,6 +840,9 @@ def export_cyclonedx(d):
     # Determine runtime packages for scope assignment
     runtime_recipes = list_runtime_recipes(d)
 
+    # Determine recipes explicitly requested by the image author.
+    image_install_recipes = list_image_install_recipes(d)
+
     # Determine which recipes to include
     recipes = set()
     if d.getVar('CYCLONEDX_RUNTIME_PACKAGES_ONLY') == "1":
@@ -754,6 +855,7 @@ def export_cyclonedx(d):
     # Always include explicitly requested recipes (e.g. optee-os embedded in fitImage)
     # Resolve virtual/* entries via PREFERRED_PROVIDER_*
     extra_recipes = set()
+
     for recipe in (d.getVar('CYCLONEDX_EXTRA_RUNTIME_RECIPES') or '').split():
         if recipe.startswith("virtual/"):
             resolved = (d.getVar("PREFERRED_RPROVIDER_" + recipe)
@@ -765,6 +867,12 @@ def export_cyclonedx(d):
             recipe = resolved
         extra_recipes.add(recipe)
     recipes = recipes.union(extra_recipes)
+
+    # Treat extra runtime recipes as direct image-install intent.
+    image_install_recipes = image_install_recipes.union(extra_recipes)
+
+    # Track direct-install components without persisting debug properties in output.
+    directly_installed_component_refs = set()
 
     # Create a bom_ref_map for dependencies sanitarization
     # And an alias_map to retrieve real pkg name
@@ -809,13 +917,22 @@ def export_cyclonedx(d):
 
         for pn_pkg in pn_list["pkgs"]:
             # Avoid multiple pkgs referencing the same cpe
-            if any(sbom_pkg["cpe"] == pn_pkg["cpe"] for sbom_pkg in sbom["components"]):
+            existing_component = next((sbom_pkg for sbom_pkg in sbom["components"]
+                                       if sbom_pkg["cpe"] == pn_pkg["cpe"]), None)
+            if existing_component:
+                if pkg in image_install_recipes:
+                    existing_ref = existing_component.get("bom-ref")
+                    if existing_ref:
+                        directly_installed_component_refs.add(existing_ref)
                 continue
 
             # Add scope field to indicate runtime vs build-time component
             # Can be disabled for certain SBOM profiles or tool compatibility
             if d.getVar('CYCLONEDX_ADD_COMPONENT_SCOPES') == "1":
                 pn_pkg["scope"] = "required" if pkg in runtime_recipes or pkg in extra_recipes else "excluded"
+
+            if pkg in image_install_recipes:
+                directly_installed_component_refs.add(pn_pkg["bom-ref"])
 
             sbom["components"].append(pn_pkg)
         for pn_cve in pn_list["cves"]:
@@ -869,6 +986,16 @@ def export_cyclonedx(d):
                 updated_entry = {"ref": component_ref, "dependsOn": resolved_depends}
                 if updated_entry not in sbom["dependencies"]:
                     sbom["dependencies"].append(updated_entry)
+
+    # Add a root dependency node as the first entry.
+    # It references metadata.component and points to all directly installed components.
+    directly_installed_refs = sorted(directly_installed_component_refs)
+
+    root_dep_entry = {
+        "ref": metadata_component_ref,
+        "dependsOn": directly_installed_refs
+    }
+    sbom["dependencies"].insert(0, root_dep_entry)
 
     # Replace SBOM serial placeholder in VEX vulnerabilities
     # This must be done after all vulnerabilities are collected to ensure each image

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -42,6 +42,11 @@ CYCLONEDX_IMAGE_VERSION ??= "${DISTRO_VERSION}${IMAGE_VERSION_SUFFIX}"
 # embedded directly into the image (e.g. OP-TEE inside a fitImage).
 CYCLONEDX_EXTRA_RUNTIME_RECIPES ??= ""
 
+# Space-separated list of CycloneDX documents produced by the recipe itself, for
+# language ecosystems that resolve their own dependency tree (cargo, npm, go).
+# Their components and dependency edges are merged into the image BOM verbatim.
+CYCLONEDX_EXTRA_BOM_FILES ??= ""
+
 # Add component licenses (as specified within the recipe) to the SBOM
 CYCLONEDX_ADD_COMPONENT_LICENSES ??= "1"
 
@@ -206,6 +211,44 @@ python do_populate_cyclonedx() {
 
     pn_list["dependencies"] = dependencies
 
+    # Fold in CycloneDX documents produced by the recipe itself (cargo, npm, go,
+    # ...). They are stored aside from "pkgs"/"dependencies" because they are
+    # already fully resolved and must bypass the CPE deduplication and the
+    # recipe-name dependency remapping that export_cyclonedx() applies to
+    # Yocto-derived components.
+    extra_components = []
+    extra_dependencies = []
+    extra_roots = []
+    for bom_path in (d.getVar("CYCLONEDX_EXTRA_BOM_FILES") or "").split():
+        if not os.path.exists(bom_path):
+            bb.warn(f"CYCLONEDX_EXTRA_BOM_FILES: {pn}: no such file, skipping: {bom_path}")
+            continue
+        try:
+            extra_bom = read_json(bom_path)
+        except Exception as e:
+            bb.warn(f"CYCLONEDX_EXTRA_BOM_FILES: {pn}: cannot parse {bom_path}: {e}")
+            continue
+        components = extra_bom.get("components") or []
+        # The document's own root -- metadata.component, i.e. the module the
+        # recipe builds -- is by convention not repeated in "components", yet
+        # the dependency edges reference it. Carry it over explicitly, or the
+        # merged tree hangs off a bom-ref that resolves to nothing, and remember
+        # it so export_cyclonedx() can attach the tree to the recipe.
+        root = (extra_bom.get("metadata") or {}).get("component") or {}
+        if root.get("bom-ref"):
+            components = components + [root]
+            extra_roots.append(root["bom-ref"])
+        extra_components.extend(components)
+        extra_dependencies.extend(extra_bom.get("dependencies") or [])
+        bb.debug(1, f"CYCLONEDX_EXTRA_BOM_FILES: {pn}: merged {len(components)} "
+                    f"components from {bom_path}")
+    if extra_components:
+        pn_list["extra_components"] = extra_components
+    if extra_dependencies:
+        pn_list["extra_dependencies"] = extra_dependencies
+    if extra_roots:
+        pn_list["extra_roots"] = extra_roots
+
     # write partial sbom to the recipes work folder
     write_json(os.path.join(d.getVar("CYCLONEDX_PNDATA_WORKDIR"), f"{pn}.json"), pn_list)
 
@@ -221,6 +264,7 @@ do_populate_cyclonedx[sstate-inputdirs] = "${CYCLONEDX_PNDATA_WORKDIR}"
 do_populate_cyclonedx[sstate-outputdirs] = "${CYCLONEDX_PNDATA}/${SSTATE_PKGARCH}"
 do_populate_cyclonedx[vardeps] += "CYCLONEDX_PNDATA"
 do_populate_cyclonedx[vardeps] += "CYCLONEDX_COMPONENT_PROPERTIES"
+do_populate_cyclonedx[vardeps] += "CYCLONEDX_EXTRA_BOM_FILES"
 python do_populate_cyclonedx_setscene() {
     sstate_setscene(d)
 }
@@ -1017,6 +1061,58 @@ def export_cyclonedx(d):
                 updated_entry = {"ref": component_ref, "dependsOn": resolved_depends}
                 if updated_entry not in sbom["dependencies"]:
                     sbom["dependencies"].append(updated_entry)
+
+    # Fold in pre-resolved CycloneDX fragments contributed by recipes.
+    #
+    # Language ecosystems that resolve their own dependency trees (cargo, npm,
+    # go, ...) are invisible to Yocto's package model: the image BOM lists the
+    # recipe that builds the binary, but not the hundreds of modules linked into
+    # it. Such a recipe can generate a CycloneDX document at build time and
+    # attach it to its own pn fragment under "extra_components" /
+    # "extra_dependencies", and it is merged into the image BOM here.
+    #
+    # These entries already carry their own bom-refs, purls and dependency
+    # edges, so they are appended verbatim: the CPE deduplication and the
+    # recipe-name dependency remapping above apply to components derived from
+    # Yocto packages and would corrupt an externally resolved tree.
+    extra_seen_refs = {c["bom-ref"] for c in sbom["components"] if c.get("bom-ref")}
+    for pkg in recipes:
+        pn_list = pn_lists.get(pkg)
+        if not pn_list:
+            continue
+        for component in pn_list.get("extra_components", []):
+            ref = component.get("bom-ref") or component.get("purl")
+            if ref:
+                if ref in extra_seen_refs:
+                    continue
+                extra_seen_refs.add(ref)
+            sbom["components"].append(component)
+        for dep_entry in pn_list.get("extra_dependencies", []):
+            if dep_entry not in sbom["dependencies"]:
+                sbom["dependencies"].append(dep_entry)
+
+        # Attach each contributed tree to the recipe that produced it, so the
+        # modules are attributable to the binary they are linked into instead of
+        # floating unreferenced at the top level of the BOM.
+        extra_roots = pn_list.get("extra_roots") or []
+        if not extra_roots:
+            continue
+        owner_name = alias_map.get(pkg)
+        owner = bom_ref_map.get(owner_name) if owner_name else None
+        owner_ref = owner.get("bom-ref") if owner else None
+        if owner_ref in global_bom_ref_dedup_map:
+            owner_ref = global_bom_ref_dedup_map[owner_ref]
+        if not owner_ref or not any(c.get("bom-ref") == owner_ref for c in sbom["components"]):
+            bb.debug(1, f"CYCLONEDX_EXTRA_BOM_FILES: {pkg}: no component to attach "
+                        f"{len(extra_roots)} contributed tree(s) to")
+            continue
+        owner_entry = next((x for x in sbom["dependencies"] if x["ref"] == owner_ref), None)
+        if owner_entry is None:
+            owner_entry = {"ref": owner_ref, "dependsOn": []}
+            sbom["dependencies"].append(owner_entry)
+        for root_ref in extra_roots:
+            if root_ref in extra_seen_refs and root_ref not in owner_entry["dependsOn"]:
+                owner_entry["dependsOn"].append(root_ref)
 
     # Add a root dependency node as the first entry.
     # It references metadata.component and points to all directly installed components.

--- a/classes/include/include-unpatched.inc
+++ b/classes/include/include-unpatched.inc
@@ -1,4 +1,0 @@
-# SPDX-License-Identifier: MIT
-
-do_populate_cyclonedx[depends] += "${PN}:do_cve_check"
-do_populate_cyclonedx[nostamp] = "1"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PATTERN_cyclonedx = "^${LAYERDIR}/"
 BBFILE_PATTERN_IGNORE_EMPTY_cyclonedx = "1"
 
 LAYERDEPENDS_cyclonedx = "core"
-LAYERSERIES_COMPAT_cyclonedx = "whinlatter wrynose"
+LAYERSERIES_COMPAT_cyclonedx = "wrynose"

--- a/examples/automated-dependencytrack-upload.py
+++ b/examples/automated-dependencytrack-upload.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+
+"""
+SPDX-License-Identifier: CC0-1.0
+SPDX-FileCopyrightText: No Rights Reserved
+Full license text: http://creativecommons.org/publicdomain/zero/1.0/
+
+Upload CycloneDX SBOM and VEX files to DependencyTrack.
+
+This script is designed to be idempotent and safe to retry from CI/CD pipelines.
+It will:
+  1. Ensure the project/version exists:
+     a. If the version already exists, skip creation (idempotent re-run).
+     b. If a latest version exists, clone it to preserve tags, properties,
+        audit history, ACL, and policy violations.
+     c. If no project exists at all, create one from scratch (first version).
+  2. Upload the SBOM and wait for processing to complete.
+  3. Optionally upload the VEX and wait for processing to complete.
+
+The clone deliberately excludes components, dependencies, and services because
+the SBOM upload replaces them.  Cloning stale data would leave the project in
+an inconsistent state if the upload subsequently fails.
+
+Required environment variables:
+  DEPENDENCY_TRACK_URL          - Base API URL (e.g. https://dtrack.example.com/api)
+  DEPENDENCY_TRACK_TOKEN        - API key with BOM_UPLOAD + PORTFOLIO_MANAGEMENT +
+                                  VULNERABILITY_ANALYSIS permissions
+  DEPENDENCY_TRACK_PROJECT_NAME - Project name in DependencyTrack
+  VERSION                       - Project version string
+
+Usage:
+  python3 upload-to-dependency-track.py <sbom_file> [<vex_file>]
+"""
+
+import argparse
+import base64
+import logging
+import os
+import sys
+import time
+
+import requests
+import semantic_version
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+POLL_INTERVAL_SECONDS = 2
+POLL_TIMEOUT_SECONDS = 300  # 5 minutes max wait for processing
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        log.error("Required environment variable %s is not set", name)
+        sys.exit(1)
+    return value
+
+
+def parse_version(version_str: str) -> semantic_version.Version:
+    """Parse a version string into a semantic_version.Version.
+
+    Strips a leading 'v' prefix if present.  Raises ValueError if the
+    resulting string is not valid semantic versioning.
+    """
+    stripped = version_str.lstrip("v")
+    try:
+        return semantic_version.Version(stripped)
+    except ValueError:
+        raise ValueError(
+            f"Version '{version_str}' (stripped: '{stripped}') "
+            f"is not a valid semantic version"
+        )
+
+
+# ---------------------------------------------------------------------------
+# API helpers
+# ---------------------------------------------------------------------------
+class DependencyTrackClient:
+    def __init__(self, base_url: str, api_key: str):
+        # Strip trailing slash for consistent URL building
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({
+            "X-Api-Key": api_key,
+        })
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}{path}"
+
+    # -- Project operations ------------------------------------------------
+
+    def lookup_project(self, name: str, version: str) -> dict | None:
+        """Look up a project by name and version.
+
+        Returns the project dict or None if it doesn't exist.
+        """
+        resp = self.session.get(
+            self._url("/v1/project/lookup"),
+            params={"name": name, "version": version},
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_latest_project(self, name: str) -> dict | None:
+        """Get the latest version of a project by name.
+
+        Returns the project dict or None if no project with that name exists.
+        """
+        resp = self.session.get(self._url(f"/v1/project/latest/{name}"))
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+    def clone_project(
+        self, source_uuid: str, new_version: str, *, is_latest: bool,
+    ) -> str:
+        """Clone an existing project version.
+
+        Preserves tags, properties, audit history, ACL, and policy violations.
+        Skips components, dependencies, and services (replaced by SBOM upload).
+
+        Returns the processing token.
+        """
+        payload = {
+            "project": source_uuid,
+            "version": new_version,
+            "includeTags": True,
+            "includeProperties": True,
+            "includeAuditHistory": True,
+            "includeACL": True,
+            "includePolicyViolations": True,
+            "includeComponents": False,
+            "includeDependencies": False,
+            "includeServices": False,
+            "makeCloneLatest": is_latest,
+        }
+        resp = self.session.put(
+            self._url("/v1/project/clone"),
+            json=payload,
+        )
+        resp.raise_for_status()
+        token = resp.json()["token"]
+        log.info("Clone accepted, processing token: %s", token)
+        return token
+
+    def create_project(
+        self, name: str, version: str, *, is_latest: bool,
+    ) -> dict:
+        """Create a brand-new project (used only for the very first version)."""
+        payload = {
+            "name": name,
+            "version": version,
+            "classifier": "OPERATING_SYSTEM",
+            "active": True,
+            "isLatest": is_latest,
+        }
+        resp = self.session.put(
+            self._url("/v1/project"),
+            json=payload,
+        )
+        # 409 means a project with the same name/version already exists.
+        # That is fine for idempotency – just look it up instead.
+        if resp.status_code == 409:
+            log.info("Project %s %s already exists (409), looking it up", name, version)
+            project = self.lookup_project(name, version)
+            if project is None:
+                raise RuntimeError(
+                    f"Got 409 creating project but lookup returned 404 for {name} {version}"
+                )
+            return project
+        resp.raise_for_status()
+        return resp.json()
+
+    def ensure_project_version(self, name: str, version: str) -> dict:
+        """Return the project version, creating it by clone or from scratch.
+
+        Logic:
+          1. If the target version already exists -> return it (idempotent).
+          2. If a "latest" version exists        -> clone it.
+          3. Otherwise                           -> create from scratch.
+
+        The ``isLatest`` / ``makeCloneLatest`` flag is only set when the new
+        version is strictly greater than the current latest (compared as
+        semantic versions with any leading ``v`` stripped).
+        """
+        new_semver = parse_version(version)
+
+        # 1. Already exists?
+        project = self.lookup_project(name, version)
+        if project is not None:
+            log.info(
+                "Project '%s' version '%s' already exists (uuid=%s)",
+                name, version, project["uuid"],
+            )
+            return project
+
+        # 2. Clone from latest?
+        latest = self.get_latest_project(name)
+        if latest is not None:
+            latest_semver = parse_version(latest["version"])
+            is_latest = new_semver > latest_semver
+            log.info(
+                "Cloning from latest version '%s' (uuid=%s), "
+                "new version will%s be marked as latest",
+                latest["version"], latest["uuid"],
+                "" if is_latest else " NOT",
+            )
+            clone_token = self.clone_project(
+                latest["uuid"], version, is_latest=is_latest,
+            )
+            self.wait_for_token(clone_token, label="Clone")
+
+            # Look up the newly created version
+            project = self.lookup_project(name, version)
+            if project is None:
+                raise RuntimeError(
+                    f"Clone completed but lookup returned 404 for {name} {version}"
+                )
+            log.info("Cloned project uuid=%s", project["uuid"])
+            return project
+
+        # 3. First-ever version — create from scratch (always latest)
+        log.info(
+            "No existing project '%s' found, creating first version '%s'",
+            name, version,
+        )
+        project = self.create_project(name, version, is_latest=True)
+        log.info("Created project uuid=%s", project["uuid"])
+        return project
+
+    # -- BOM upload --------------------------------------------------------
+
+    def upload_bom(self, project_uuid: str, bom_path: str) -> str:
+        """Upload a CycloneDX BOM file.  Returns the processing token."""
+        log.info("Uploading SBOM from %s", bom_path)
+        with open(bom_path, "rb") as f:
+            bom_content = f.read()
+
+        bom_b64 = base64.b64encode(bom_content).decode("ascii")
+
+        payload = {
+            "project": project_uuid,
+            "bom": bom_b64,
+        }
+        resp = self.session.put(
+            self._url("/v1/bom"),
+            json=payload,
+        )
+        resp.raise_for_status()
+        token = resp.json()["token"]
+        log.info("SBOM upload accepted, processing token: %s", token)
+        return token
+
+    # -- VEX upload --------------------------------------------------------
+
+    def upload_vex(self, project_uuid: str, vex_path: str) -> str:
+        """Upload a CycloneDX VEX file.  Returns the processing token."""
+        log.info("Uploading VEX from %s", vex_path)
+        with open(vex_path, "rb") as f:
+            vex_content = f.read()
+
+        vex_b64 = base64.b64encode(vex_content).decode("ascii")
+
+        payload = {
+            "project": project_uuid,
+            "vex": vex_b64,
+        }
+        resp = self.session.put(
+            self._url("/v1/vex"),
+            json=payload,
+        )
+        resp.raise_for_status()
+        token = resp.json()["token"]
+        log.info("VEX upload accepted, processing token: %s", token)
+        return token
+
+    # -- Processing status -------------------------------------------------
+
+    def wait_for_token(self, token: str, label: str = "task") -> None:
+        """Poll the event/token endpoint until processing is complete."""
+        log.info("Waiting for %s processing to complete (token=%s) ...", label, token)
+        deadline = time.monotonic() + POLL_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            resp = self.session.get(self._url(f"/v1/event/token/{token}"))
+            resp.raise_for_status()
+            processing = resp.json().get("processing", False)
+            if not processing:
+                log.info("%s processing complete", label)
+                return
+            time.sleep(POLL_INTERVAL_SECONDS)
+
+        raise TimeoutError(
+            f"{label} processing did not complete within {POLL_TIMEOUT_SECONDS}s "
+            f"(token={token})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Upload CycloneDX SBOM and VEX to DependencyTrack",
+    )
+    parser.add_argument("sbom_file", help="Path to the CycloneDX SBOM JSON file")
+    parser.add_argument("vex_file", nargs="?", default=None,
+                        help="Path to the CycloneDX VEX JSON file (optional)")
+    args = parser.parse_args()
+
+    # Validate files exist early
+    if not os.path.isfile(args.sbom_file):
+        log.error("File not found: %s", args.sbom_file)
+        sys.exit(1)
+    if args.vex_file is not None and not os.path.isfile(args.vex_file):
+        log.error("File not found: %s", args.vex_file)
+        sys.exit(1)
+
+    api_url = require_env("DEPENDENCY_TRACK_URL")
+    api_key = require_env("DEPENDENCY_TRACK_TOKEN")
+    project_name = require_env("DEPENDENCY_TRACK_PROJECT_NAME")
+    version = require_env("VERSION")
+
+    # Validate version early so we fail fast on bad input
+    parse_version(version)
+
+    client = DependencyTrackClient(api_url, api_key)
+
+    # Step 1 – Ensure the project/version exists (clone from latest or create)
+    project = client.ensure_project_version(project_name, version)
+    project_uuid = project["uuid"]
+
+    # Step 2 – Upload SBOM and wait for processing
+    bom_token = client.upload_bom(project_uuid, args.sbom_file)
+    client.wait_for_token(bom_token, label="SBOM")
+
+    # Step 3 – Upload VEX and wait for processing (optional)
+    # The VEX must be uploaded after the SBOM has been fully processed so that
+    # DependencyTrack can match vulnerability analyses to known components.
+    if args.vex_file is not None:
+        vex_token = client.upload_vex(project_uuid, args.vex_file)
+        client.wait_for_token(vex_token, label="VEX")
+    else:
+        log.info("No VEX file provided, skipping VEX upload")
+
+    log.info("Done. Project '%s' version '%s' is up to date.", project_name, version)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        log.error("Fatal: %s", exc)
+        sys.exit(1)


### PR DESCRIPTION
Language ecosystems that resolve their own dependency trees -- cargo, npm, go -- are invisible to Yocto's package model. The image BOM lists the recipe that builds the binary but none of the modules linked into it, so a Rust service shows up as a single component while the crates it depends on, and the advisories against them, are missing entirely.

Add CYCLONEDX_EXTRA_BOM_FILES: a space-separated list of CycloneDX documents generated by the recipe itself. do_populate_cyclonedx reads them and stores their components and dependency edges in the recipe's pn fragment under extra_components / extra_dependencies, and export_cyclonedx() merges those into the image BOM.

They are kept apart from "pkgs"/"dependencies" on purpose. Such documents are already fully resolved and carry their own bom-refs, purls and dependency edges, so they must bypass the CPE deduplication and the recipe-name dependency remapping that are applied to Yocto-derived components -- both of which would corrupt an externally resolved tree. Duplicate bom-refs (the same crate pulled in by two recipes) are dropped, keeping the first occurrence.

A missing or unparsable file warns and is skipped, so a build does not fail because a language ecosystem could not emit its SBOM.