### PR TITLE
fix calls to getVar

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -252,7 +252,7 @@ python do_populate_cyclonedx() {
     extra_roots = []
     for bom_path in (d.getVar("CYCLONEDX_EXTRA_BOM_FILES") or "").split():
         if not os.path.exists(bom_path):
-            if d.GetVar("CYCLONEDX_EXTRA_BOM_FILES_FAIL_ON_BROKEN_BOM_FILES") == "0":
+            if d.getVar("CYCLONEDX_EXTRA_BOM_FILES_FAIL_ON_BROKEN_BOM_FILES") == "0":
                 bb.warn(f"CYCLONEDX_EXTRA_BOM_FILES: {pn}: no such file, skipping: {bom_path}")
                 continue
             else:
@@ -260,7 +260,7 @@ python do_populate_cyclonedx() {
         try:
             extra_bom = read_json(bom_path)
         except Exception as e:
-            if d.GetVar("CYCLONEDX_EXTRA_BOM_FILES_FAIL_ON_BROKEN_BOM_FILES") == "0":
+            if d.getVar("CYCLONEDX_EXTRA_BOM_FILES_FAIL_ON_BROKEN_BOM_FILES") == "0":
                 bb.warn(f"CYCLONEDX_EXTRA_BOM_FILES: {pn}: cannot parse {bom_path}, skipping: {e}")
                 continue
             else:


### PR DESCRIPTION
While #119 was a quick fix to get the CI's up and running again, this fix also fixes the code itself to be runnable. Which only affects you if you use the `CYCLONEDX_EXTRA_BOM_FILES_FAIL_ON_BROKEN_BOM_FILES` variables. I do not use it so I can not test if there is more to fix.